### PR TITLE
chore(docs): add missing link to "Auto-Mounting Secondary Drives"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,3 +150,4 @@ nav:
       - "Reset Forgotten User Password": Advanced/Reset_Forgotten_User_Password.md
       - "Creating A Custom Bazzite Image": Advanced/creating_custom_image.md
       - "Contributing to Bazzite": Advanced/Contributing_to_bazzite.md
+      - "Auto-Mounting Secondary Drives": Advanced/Auto-Mounting_Secondary_Drives.md


### PR DESCRIPTION
* Link to "Auto-Mounting Secondary Drives" under the Advanced section in the documentation