### PR TITLE
chore(docs): Add Decky Setup section to Handheld wiki

### DIFF
--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/index.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/index.md
@@ -61,6 +61,16 @@ The handheld is not listed here and a general guide is under “Other Handhelds.
 
 > **Note**: Gyro functionality **requires** DualSense emulation
 
+# Decky Setup
+
+To install [Decky Loader](https://decky.xyz), open a host terminal and enter:
+
+```bash
+ujust setup-decky
+```
+
+You can access Decky Loader by pressing the 'side menu button' once from within Steam Gamemode or Steam Big Picture Mode.
+
 # Decky Plugins
 
 > **Note**: Decky may break or uninstall after updates especially if the Steam client or Gamescope is updated.


### PR DESCRIPTION
* Adding section for how to install Decky in Bazzite since we have info on the Decky plugins but not Decky itself
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
