### PR TITLE
Update Steam_Gaming_Mode.md for QAM hotkey change

### DIFF
--- a/src/Handheld_and_HTPC_edition/Steam_Gaming_Mode.md
+++ b/src/Handheld_and_HTPC_edition/Steam_Gaming_Mode.md
@@ -93,7 +93,7 @@ Select "unhide" to have GRUB appear on boot.
 
 ### How do I open the Quick Access Menu (QAM) with a physical keyboard?
 
-<kbd>Ctrl</kbd>+<kbd>2</kbd>
+<kbd>Super</kbd>+<kbd>2</kbd>
 
 ### Change physical keyboard layout for Steam Gaming Mode
 


### PR DESCRIPTION
Change the hotkey to open QAM from `ctrl + 2` to `super + 2` to reflect the change on https://github.com/ublue-os/bazzite/pull/1724.
We can merge it once v3.7.0 has been released.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
