### PR TITLE
feat: Add devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 			]
 		}
 	},
-	"onCreateCommand": "sudo apt-get update -y && sudo apt install -y libcairo2 && ./utils/install-deps.sh"
+	"onCreateCommand": "sudo apt-get update -y && sudo apt install -y libcairo2 && sudo apt clean -y && ./utils/install-deps.sh"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 				"-ms-python.autopep8",
 				"ms-python.black-formatter",
 				"donjayamanne.python-environment-manager",
-				"njpwerner.autodocstring"
+				"njpwerner.autodocstring",
+				"GitHub.vscode-pull-request-github"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
+	"features": {
+		"ghcr.io/meaningful-ooo/devcontainer-features/homebrew:2": {},
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"-ms-python.autopep8",
+				"ms-python.black-formatter",
+				"donjayamanne.python-environment-manager",
+				"njpwerner.autodocstring"
+			]
+		}
+	},
+	"onCreateCommand": "sudo apt-get update -y && sudo apt install -y libcairo2 && ./utils/install-deps.sh"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
This will help us to avoid the "but it works in my machine".

Given universal blue heavily promotes containers, would make sense our
docs were to be built and developed with them.