### PR TITLE
docs: remove images from image chart that don't exist

### DIFF
--- a/src/General/FAQ.md
+++ b/src/General/FAQ.md
@@ -79,8 +79,8 @@ Both types of images also come with the choice of using [KDE Plasma](https://kde
 | `bazzite-asus-nvidia-open`       | KDE Plasma          | No                | ASUS Laptops (Newer Nvidia GPUs)               | Desktop       |
 | `bazzite-gnome-asus-nvidia` | GNOME               | No                | ASUS Laptops (Nvidia GPUs)               | Desktop       |
 | `bazzite-gnome-asus-nvidia-open` | GNOME               | No                | ASUS Laptops (Newer Nvidia GPUs)               | Desktop       |
-| `bazzite-asus-deck` / `bazzite-ally`              | KDE Plasma          | Yes               | ASUS Laptops (Steam Gaming Mode Enabled) | Handheld/HTPC |
-| `bazzite-asus-deck-gnome` / `bazzite-ally-gnome`        | GNOME               | Yes               | ASUS Laptops (Steam Gaming Mode Enabled) | Handheld/HTPC |
+| `bazzite-ally`              | KDE Plasma          | Yes               | ASUS Laptops (Steam Gaming Mode Enabled) | Handheld/HTPC |
+| `bazzite-ally-gnome`        | GNOME               | Yes               | ASUS Laptops (Steam Gaming Mode Enabled) | Handheld/HTPC |
 
 ### Who are the target audiences?
 


### PR DESCRIPTION
Removed "bazzite-asus-deck" and "bazzite-asus-deck-gnome" images from the Bazzite Image List since these images do not exist in the list of downloadable/rebasable Bazzite images.