### PR TITLE
Update NTFS note in Auto-Mount Guides

### DIFF
--- a/src/Advanced/GNOME_Disks_Auto-Mount_Guide.md
+++ b/src/Advanced/GNOME_Disks_Auto-Mount_Guide.md
@@ -70,7 +70,7 @@ defaults,noatime,nofail,rw,users,exec
 
 !!! note
     
-    Do not use the NTFS filesystem for game library storage in Bazzite, and it is not supported and you will get lots of issues with it. NTFS is **not** intended as a game drive for Bazzite.
+    Bazzite does **not** support NTFS. Using the NTFS filesystem will lead to a lot of issues and should be avoided.
 
 ### Permissions for the drive
 

--- a/src/Advanced/KDE_Partition_Manager_Auto_Mount_Guide.md
+++ b/src/Advanced/KDE_Partition_Manager_Auto_Mount_Guide.md
@@ -81,7 +81,7 @@ defaults,noatime,nofail,rw,users,exec
 
 !!! note
     
-    Do not use the NTFS filesystem for game library storage in Bazzite, and it is not supported and you will get lots of issues with it. NTFS is **not** intended as a game drive for Bazzite.
+    Bazzite does **not** support NTFS. Using the NTFS filesystem will lead to a lot of issues and should be avoided.
 
 ### Advanced Options (Not required for most setups)
 


### PR DESCRIPTION
Update NTFS to be more direct that Bazzite does not support NTFS no matter what it's use is.
