### PR TITLE
Incorrect ujust command to fix steam

### DIFF
--- a/src/Handheld_and_HTPC_edition/quirks.md
+++ b/src/Handheld_and_HTPC_edition/quirks.md
@@ -173,7 +173,7 @@ Save it and place it in the `Desktop` directory.
 Open a host terminal and **enter**:
 
 ```
-ujust fix-steam
+ujust fix-reset-steam
 ```
 
 ##### TTY (if you cannot access Desktop Mode)
@@ -182,7 +182,7 @@ Access a TTY session with <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F4</kbd> and login
 **Enter**:
 
 ```
-ujust fix-steam
+ujust fix-reset-steam
 ```
 
 #### How do I specify the correct monitor for Gaming Mode to use? (HTPC only)


### PR DESCRIPTION
There is no `ujust fix-steam` command, the correct command is `ujust fix-reset-steam`

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
