### PR TITLE
docs: fixed error in hibernation guide

### DIFF
--- a/src/Advanced/swapfile.md
+++ b/src/Advanced/swapfile.md
@@ -10,8 +10,6 @@ authors:
 
 ## Make Swap Subvolume (e.g., due to Snapper)
 ```
-sudo mkdir -p /var/swap
-
 sudo btrfs subvolume create /var/swap
 
 sudo semanage fcontext -a -t var_t /var/swap


### PR DESCRIPTION
`sudo btrfs subvolume create /var/swap` seems to create the folder when it creates the subvolume, if you try and make the folder first you can't make the subvolume