### PR TITLE
Revert Discourse link back to "Forums"

### DIFF
--- a/src/Resources.md
+++ b/src/Resources.md
@@ -2,7 +2,7 @@
 title: Social Platforms
 ---
 
-## [:simple-discourse: Project News](https://universal-blue.discourse.group/tag/bazzite-news)
+## [:simple-discourse: Forums](https://universal-blue.discourse.group/tag/bazzite-news)
 
 ## [:simple-discord: Discord](https://discord.gg/WEu6BdFEtp) <sup>([Answer Overflow](https://www.answeroverflow.com/c/1072614816579063828/1143023993041993769))</sup>
 


### PR DESCRIPTION
I changed this to Project News because I thought the Discourse was staying locked from other users posting for eternity.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
