### PR TITLE
fix(quirks): improve regex for connected displays and add back old commands

### DIFF
--- a/src/Handheld_and_HTPC_edition/quirks.md
+++ b/src/Handheld_and_HTPC_edition/quirks.md
@@ -34,8 +34,22 @@ Then add this to the file:
 Change `DP-1` to the correct output.
 You can find your display outputs using the command
 
+KDE:
 ```
-grep -r '^connected' /sys/class/drm/*/status | grep -Po 'card.-e\K([^/]*)'
+kscreen-doctor -o
+```
+
+GNOME:
+```
+gnome-randr
+```
+
+!!! note
+
+    It has been reported that some systems dont properly report the Display Output name when using gnome-randr, you can run the command below to list all the connected output names without any details so that you can compare them with what the above commands report.
+
+```
+grep -r '^connected' /sys/class/drm/*/status | grep -Po 'card.?-\K([^/]*)'
 ```
 
 Save with <kbd>CTRL</kbd> + <kbd>X</kbd> then pressing <kbd>Y</kbd> followed by <kbd>ENTER</kbd>


### PR DESCRIPTION
noticed the old commands were gone, the command that replaced them didnt work and also didnt give a lot of details.
added a compromise of adding back the old commands and fixing the grep command.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
