### PR TITLE
chore: change wording regarding Discord screen sharing

### DIFF
--- a/src/General/issues_and_resolutions.md
+++ b/src/General/issues_and_resolutions.md
@@ -24,9 +24,9 @@ Note: This fix also fixes the lag in Game Mode on Nvidia GPUs, however, this com
 
 ## Discord screen-sharing is not working
 
-**Issue:** When you try to share your screen in Discord, it simply closes the dialogue box and does not share the screen.
+**Issue:** When you try to share your screen in Discord, it simply closes the dialogue box or does not work, as Discord might have broken the screen sharing feature in Linux again.
 
-**Resolution:** You can install Discord's official **Discord Canary** client, which is their alpha/test version of Discord. You can install **Discord Canary** by opening the terminal and running:
+**Resolution:** You can install Discord's official **Discord Canary** client, which is their alpha/test version of Discord and it might have been fixed there. You can install **Discord Canary** by opening the terminal and running:
 
 ```bash
 flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo


### PR DESCRIPTION
This was added back when screensharing for wayland on linux was in alpha and constantly broke

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
