### PR TITLE
feat: remove out of date discord screen sharing section, and add section to document the Gigabyte b550 wake fix.

### DIFF
--- a/src/General/issues_and_resolutions.md
+++ b/src/General/issues_and_resolutions.md
@@ -206,7 +206,7 @@ and then try to connect again.
 
 **Issue:** Once a Gigabyte b550 motherboard suspends, it does not properly resume, and the display remains black until a reboot.
 
-**Resolution:** This can be fixed by disabling GPP0 and GPP8 wakeup. A hidden ujust is provided for this process:
+**Resolution:** This can be fixed by disabling GPP0 and GPP8 wakeup. A hidden ujust is provided to toggle this fix:
 ```bash
 ujust _toggle-gigabyte-wake-fix
 ```


### PR DESCRIPTION
feat: document the Gigabyte b550 wake fix so its easier to discover since an affected user is unlikely to be able to find the hidden ujust.
fix: remove discord screen sharing section since the fix landed in stable discord and it is generally not something users need to worry about anymore.
 
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
