### PR TITLE
docs: add software-installation decision tree

### DIFF
--- a/src/Installing_and_Managing_Software/index.md
+++ b/src/Installing_and_Managing_Software/index.md
@@ -22,6 +22,36 @@ Fedora Atomic Desktops have read-only root files to prioritize stability.  There
 6. [**AppImage**](./AppImage.md) (_Portable Graphical Applications_) - Portable universal package format that relies on specific host libraries at a system-level, usually obtained from a project's website.
 7. [**`rpm-ostree`**](./rpm-ostree.md) (_System-Level Packages_) - Layer Fedora packages at a system-level (**not recommended, use as a last resort**)
 
+```mermaid
+---
+title: "Installing Applications on Bazzite: A Decision Tree"
+---
+flowchart TD
+    gui@{ shape: question, label: "Is it a GUI?" }
+    flatpak@{ shape: question, label: "Does it have a Flatpak?" }
+    brew@{ shape: question, label: "Does it have a brew formula?" }
+    distrobox@{ shape: question, label: "Can you install it in a distrobox?" }
+    appimage@{ shape: question, label: "Does it have an AppImage?" }
+    layerQ@{ shape: question, label: "Can you layer it?" }
+    inst[Install it]
+    export[Install and export it]
+    gearlever[Download it and put it in Gear Lever]
+    layer[Layer it, but here be dragons!]
+    custImg[Look into making a custom Bazzite image]
+    gui-->|No|brew
+    gui-->|Yes|flatpak
+    brew-->|Yes|inst
+    brew-->|No|distrobox
+    flatpak-->|Yes|inst
+    flatpak-->|No|distrobox
+    distrobox-->|Yes|export
+    distrobox-->|No|appimage
+    appimage-->|Yes|gearlever
+    appimage-->|No|layerQ
+    layerQ-->|Yes|layer
+    layerQ-->|No|custImg
+```
+
 ## How do I run Windows applications?
 
 **Use a [WINE](https://www.winehq.org/) front-end**:


### PR DESCRIPTION
Add decision tree for software installation methods (for applications only, not services), as some users find this easier to follow than the list of methods.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
