### PR TITLE
docs: remove the second 'Shared Drive' tab for dualboot

### DIFF
--- a/src/General/Installation_Guide/dual_boot_setup_guide.md
+++ b/src/General/Installation_Guide/dual_boot_setup_guide.md
@@ -11,7 +11,7 @@ title: Dual Boot Preliminary and Post-Installation Setup Guide
 1. Installing Bazzite with a shared drive.
 2. Installing Bazzite on a separate drive.
 
-=== "Shared Drive (Automatic Partitioning)"
+=== "Shared Drive"
 
     1. (In Windows) Disable **Bitlocker encryption** and **fastboot**, and reboot.
     2. (In Windows) Resize the Windows partition with the Disk Management app to have enough space for Bazzite.
@@ -20,15 +20,6 @@ title: Dual Boot Preliminary and Post-Installation Setup Guide
     <i><small>Source: [diskpart.com](https://www.diskpart.com/windows-10/windows-10-disk-management-0528.html)</small></i>
     3. Run the Bazzite installer with the automatic partitioning option.
     4. Reboot into Bazzite and run `ujust regenerate-grub` in the terminal to add Windows to the GRUB.
-
-=== "Shared Drive (Manual Partitioning) [Legacy ISO Only]"
-
-    1. (In Windows) Resize the Windows partition with the Disk Management app to have enough space for Bazzite.
-    Usually should look something like this:
-    ![](/img/dualbooting_partitions_windows.png)
-    <i><small>Source: [diskpart.com](https://www.diskpart.com/windows-10/windows-10-disk-management-0528.html)</small></i>
-    2. Run the Bazzite installer with [manual partitioning](./manual_partitioning.md).
-    3. Reboot into Bazzite and run `ujust regenerate-grub` in the terminal to add Windows to the GRUB.
 
 
 === "Separate Drive"


### PR DESCRIPTION
There are 2 tabs 'shared drive' under the dualboot guide for some reason
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
