### PR TITLE
docs: Update Common gaming issues with multi-user WINE quirk

### DIFF
--- a/src/Gaming/Common_gaming_issues.md
+++ b/src/Gaming/Common_gaming_issues.md
@@ -23,20 +23,25 @@ If you encounter issues with a game launching on Steam:
 A log file should appear in your Home directory named after the game's application ID number.
 You can use this log file for requesting support.
 
-## Steam games not launching at all
+## Steam Games Not Launching
 
 ### NTFS Permissions
-Make sure your games are **not** on a NTFS (Windows) partition. More information [here](./Hardware_compatibility_for_gaming.md#unsupported-filesystems-for-secondary-drives)
+
+Make sure your games are **not** on a NTFS (Windows) partition. More information can be found [**here**](./Hardware_compatibility_for_gaming.md#unsupported-filesystems-for-secondary-drives).
 
 ### Multi-User WINE Quirks
-Sometimes Steam games will completely refuse to launch on a secondary user account. 
-This can be due to the ownership of the WINE prefix files. 
-You might see an error like this in ` ~/.local/share/Steam/logs/console-linux.txt ` on the secondary user account:
 
+!!! note
+
+    Bazzite-Deck does not support multiple Linux user accounts, this information only applies to the Desktop edition of Bazzite.
+
+Sometimes Steam games will completely refuse to launch on a secondary user account. This can be due to the ownership of the WINE prefix files. You might see an error like this in ` ~/.local/share/Steam/logs/console-linux.txt ` on the secondary user account:
+
+```
 wineserver: /SteamLibrary/steamapps/compatdata/377160/pfx is not owned by you
 ```
 
-You can fix this by creating a separate Steam Library folder just to hold the compatdata for WINE and creating a symlink for the other folders you'd like (like common game data).
+You can fix this by creating a separate Steam library folder to hold the prefix data for Proton and creating a symbolic link (_symlink_) for the other folders (like common game data).
 
 ```
 USER2@bazzite: /mnt/ExtraStuff/USER2SteamLibrary/steamapps$ ls -la
@@ -49,10 +54,9 @@ drwxr-xr-x. 3 USER2 USER2         4096 Jan 29 15:13 compatdata
 lrwxrwxrwx. 1 USER2 USER2           56 Jan 29 15:12 shadercache -> /mnt/ExtraStuff/USER1SteamLibrary/steamapps/shadercache/
 lrwxrwxrwx. 1 USER2 USER2           49 Jan 29 15:12 temp
 lrwxrwxrwx. 1 USER2 USER2           53 Jan 29 15:12 workshop
-
 ```
 
-You might similarly have to copy or symlink the appmanifest files from each library for games to show up properly in each Steam library. 
+Similarly copy or symlink the appmanifest files from each library for games to show up properly in each Steam library. 
 
 ## Native Linux Port Versus Windows Version
 


### PR DESCRIPTION
Adjusted formatting of section "Steam games not launching at all" section, added multi-user WINE issue that can occur when launching Steam games on a secondary user account.

