### PR TITLE
fix: typo in note block on general faq page

### DIFF
--- a/src/General/FAQ.md
+++ b/src/General/FAQ.md
@@ -45,7 +45,7 @@ A version of Bazzite that specifically caters to software development. It is not
 
 #### Bazzite Image Chart Example
 
-!!! not
+!!! note
 
     This does not include all of the Bazzite images.
 


### PR DESCRIPTION
fixed minor typo on general faq page