### PR TITLE
fix(docs): Fix link to Nvidia issues

### DIFF
--- a/src/Gaming/Hardware_compatibility_for_gaming.md
+++ b/src/Gaming/Hardware_compatibility_for_gaming.md
@@ -32,7 +32,7 @@ title: Hardware Compatibility for Linux Gaming
   - RX 4xx series and up
     - 600M/700M integrated GPUs are also supported
 - Intel Arc GPUs are supported with **minor caveats** compared to AMD hardware
-- Nvidia GPU support is supported with [**major caveats**](/Handheld_and_HTPC_edition/quirks/#nvidia-exclusive-issues) compared to AMD hardware out of control of the Bazzite maintainers
+- Nvidia GPU support is supported with [**major caveats**](/Handheld_and_HTPC_edition/quirks/#nvidia-gpu-exclusive-issues-with-steam-gaming-mode) compared to AMD hardware out of control of the Bazzite maintainers
 - Requires a [**Steam**](https://store.steampowered.com/) account
   - Signing up for an account can be done post-installation if you don't have one already
 


### PR DESCRIPTION
Link goes to missing or renamed #nvidia-exclusive-issues URL fragment; #nvidia-gpu-exclusive-issues-with-steam-gaming-mode is the current and working fragment

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
