### PR TITLE
docs(arctis): update broken author links

### DIFF
--- a/src/Advanced/arctis-manager.md
+++ b/src/Advanced/arctis-manager.md
@@ -1,7 +1,8 @@
 ---
 title: Installing Arctis Manager
 authors:
-  - "@elegos, @aiyahhh"
+  - "@elegos"
+  - "@ifeign"
 tags:
   - Community
 search:


### PR DESCRIPTION
fixes broken URL that currently goes to a 404: https://github.com/elegos,%20@aiyahhh

putting each author on a separate line and fixing my name from aiyahhh to ifeign (used the wrong one when i wrote this) should fix it. Now each author will have a working URL

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
## description

Apologies, I noticed a small issue in the PR that was JUST merged. This should fix the broken authors link as well as credit myself properly - I initially used Aiyahhh which is my Discord handle.