### PR TITLE
Docs: Replace the 'rebase to signed image' instructions with ujust

### DIFF
--- a/src/General/Installation_Guide/alternate-install-guide.md
+++ b/src/General/Installation_Guide/alternate-install-guide.md
@@ -52,10 +52,9 @@ Please remove the Fedora Flatpak remote using the Warehouse application.  This w
 Once everything is setup properly, then you should rebase from the **unsigned image** to the **signed image** for security reasons, so **enter this command** in the host terminal:
 
 ```command
-rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/<IMAGE>
-```
-
-Replace **`<IMAGE>`** with the image you're using.
+ujust verify-image
+``` 
+After the command is completed, reboot your device.
 
 ## Video Tutorial
 


### PR DESCRIPTION
there is a ujust for verifying your image now that does this all automatically
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
