### PR TITLE
docs: add csm hint to secure boot guide

### DIFF
--- a/src/General/Installation_Guide/secure_boot.md
+++ b/src/General/Installation_Guide/secure_boot.md
@@ -24,7 +24,7 @@ Bazzite supports Secure Boot however Universal Blue's key must be enrolled to us
 
 - Entering the password will register invisible characters for security purposes, so you will not be able to see what you are typing!
 - Updating your BIOS may re-enable Secure Boot and you may have to follow **"Method B"** after updating it to resolve the black screen on boot complaining about loading the kernel first.
-- Secure Boot is incompatible with [CSM (Compatibility Support Module) / legacy](../FAQ.md#does-bazzite-support-csmlegacy-boot) mode. Make sure it is **disabled** and not set to `enabled` or `auto`.
+- Secure Boot is incompatible with [CSM (Compatibility Support Module) / legacy](../General/FAQ.md#does-bazzite-support-csmlegacy-boot) mode. Make sure it is **disabled** and not set to `enabled` or `auto`.
 - The Steam Deck does **not** come with secure boot enabled and does not ship with any keys enrolled by default, do not enable Secure Boot on your Steam Deck unless you absolutely know what you're doing.
 
 ## Error Message (if key is **not** enrolled properly):


### PR DESCRIPTION
Added hint to the secure boot guide that CSM needs to be `disabled` when enrolling the secure boot platform key.

Context:
When I tried to set up secure boot via Method B described, the enrollment did not succeed until I changed the CSM setting in the UEFI from `auto` to `disabled` (did not get a warning message from the installer before). I hope adding this will help other users troubleshoot as well.
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
