### PR TITLE
feat: re-add rufus support

### DIFF
--- a/src/General/Installation_Guide/install-guide.md
+++ b/src/General/Installation_Guide/install-guide.md
@@ -22,7 +22,7 @@ https://www.youtube.com/watch?v=lBqbk6Z8HrQ
 - One of the following programs to flash/boot the ISO:
   - **Ventoy** ([Windows, Linux](https://www.ventoy.net/))
   - **Fedora Media Writer** ([Windows/macOS](https://github.com/FedoraQt/MediaWriter/releases), [Linux](https://flathub.org/en/apps/org.fedoraproject.MediaWriter))
-  - **Rufus** ([Windows](https://rufus.ie/)) using DD image mode
+  - **Rufus** ([Windows](https://rufus.ie/)) (DD Image mode required)
 - A physical wired keyboard is **recommended** and **required for devices without a touchscreen**.
   - An on-screen keyboard exists for scenarios where you do not have a physical USB keyboard.
     - A touchscreen display or a mouse is required to navigate the installer properly.

--- a/src/General/Installation_Guide/install-guide.md
+++ b/src/General/Installation_Guide/install-guide.md
@@ -21,7 +21,8 @@ https://www.youtube.com/watch?v=lBqbk6Z8HrQ
 - A 16GB+ bootable medium like a Flash Drive
 - One of the following programs to flash/boot the ISO:
   - **Ventoy** ([Windows, Linux](https://www.ventoy.net/))
-  - **Fedora Media Writer** ([**Windows/macOS**](https://github.com/FedoraQt/MediaWriter/releases), [**Linux**](https://flathub.org/en/apps/org.fedoraproject.MediaWriter))
+  - **Fedora Media Writer** ([Windows/macOS](https://github.com/FedoraQt/MediaWriter/releases), [Linux](https://flathub.org/en/apps/org.fedoraproject.MediaWriter))
+  - **Rufus** ([Windows](https://rufus.ie/)) using DD image mode
 - A physical wired keyboard is **recommended** and **required for devices without a touchscreen**.
   - An on-screen keyboard exists for scenarios where you do not have a physical USB keyboard.
     - A touchscreen display or a mouse is required to navigate the installer properly.


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
Rufus can be used using DD image mode similarly how Fedora Media Writer works, I've verified on my machine. Rufus even mentions to use DD image mode instead if ISO image mode didn't work (it certainly wouldn't due to Rufus picking NTFS, nothing else). It would be the last item to try out however, FMW and Ventoy are preferred options over it.

<img width="626" height="357" alt="ISOHybrid" src="https://github.com/user-attachments/assets/09080711-186e-41f1-895a-3a1062e8cb9d" />