### PR TITLE
fix: rename ujust setup-waydroid to configure-waydroid

### DIFF
--- a/src/Installing_and_Managing_Software/Waydroid_Setup_Guide.md
+++ b/src/Installing_and_Managing_Software/Waydroid_Setup_Guide.md
@@ -21,7 +21,7 @@ title: Waydroid Setup Guide
 Open a host terminal and **enter this command to setup Waydroid**:
 
 ```bash
-ujust setup-waydroid
+ujust configure-waydroid
 ```
 
 ### Initialize Waydroid
@@ -56,7 +56,7 @@ waydroid session stop
 Open a host terminal and enter this **command**:
 
 ```
-ujust setup-waydroid
+ujust configure-waydroid
 ```
 
 Selecting `Configure Waydroid` will allow users to install additional Android tweaks with the [Waydroid Extras Scripts.](https://github.com/casualsnek/waydroid_script#waydroid-extras-script)
@@ -128,7 +128,7 @@ This section is dedicated to more specific operations and issues within Waydroid
 To install it, run the following `ujust` command:
 
 ```bash
-ujust setup-waydroid helper
+ujust configure-waydroid helper
 ```
 
 You can alternatively go directly to their [releases](https://github.com/waydroid-helper/waydroid-helper/releases) and install the latest AppImage via GearLever.
@@ -211,7 +211,7 @@ This is only intended for users who have multiple GPUs in their hardware who exp
 **Enter in a host terminal**:
 
 ```
-ujust setup-waydroid
+ujust configure-waydroid
 ```
 
 Then `Select GPU for Waydroid` which will give the option on what GPU to utilize for Waydroid to fix graphical corruptions.
@@ -225,5 +225,5 @@ Then `Select GPU for Waydroid` which will give the option on what GPU to utilize
 If you experience issues or want a fresh Waydroid container, then select `Reset Waydroid` after **entering**:
 
 ```
-ujust setup-waydroid
+ujust configure-waydroid
 ```

--- a/src/Installing_and_Managing_Software/ujust.md
+++ b/src/Installing_and_Managing_Software/ujust.md
@@ -96,7 +96,7 @@ These are just some of the common Bazzite `ujust` script examples, there are muc
 
 ### Configuration/Enabling Scripts
 
-- **ujust setup-waydroid** - a configuration helper for Waydroid. More information in [Waydroid Setup Guide](../Installing_and_Managing_Software/Waydroid_Setup_Guide.md)
+- **ujust configure-waydroid** - a configuration helper for Waydroid. More information in [Waydroid Setup Guide](../Installing_and_Managing_Software/Waydroid_Setup_Guide.md)
 - **ujust setup-virtualization** - setup and configure virtualization and vfio
 - **ujust setup-sunshine** - toggle Sunshine Game Streaming host on or off
 - **ujust setup-luks-tpm-unlock** - enable auto LUKS unlock via TPM


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
`ujust setup-waydroid` doesn't exist currently. Ideally it should have an alias in this case but for now let's just rename it here