### PR TITLE
docs(install): don't specify "dd image mode" for rufus

### DIFF
--- a/src/General/Installation_Guide/install-guide.md
+++ b/src/General/Installation_Guide/install-guide.md
@@ -22,7 +22,7 @@ https://www.youtube.com/watch?v=lBqbk6Z8HrQ
   - Booting from a SD or microSD card may work, but not all firmware support this.
 - One of the following programs to flash/boot the ISO:
   - **Fedora Media Writer (recommended)** ([Windows/macOS](https://github.com/FedoraQt/MediaWriter/releases), [Linux](https://flathub.org/en/apps/org.fedoraproject.MediaWriter))
-  - **Rufus** ([Windows](https://rufus.ie/)) (DD Image mode **required**)
+  - **Rufus** ([Windows](https://rufus.ie/))
   - **Ventoy** ([Windows, Linux](https://www.ventoy.net/)) (note: Ventoy needs [**extra steps for Secure Boot Support to work**](https://www.ventoy.net/en/doc_secure.html))
 - A physical wired keyboard is **recommended** and **required for devices without a touchscreen**.
   - An on-screen keyboard exists for scenarios where you do not have a physical USB keyboard.

--- a/src/General/Installation_Guide/legacy-install.md
+++ b/src/General/Installation_Guide/legacy-install.md
@@ -19,8 +19,11 @@ This guide is only for the legacy ISOs which are still supported at this time du
 - A way to download the Bazzite ISO
   - A download manager (like [**Motrix**](https://motrix.app/)) if the direct download for the Bazzite ISO fails or is downloading too slow.
 - A 16GB+ bootable medium like a Flash Drive
-  - Software to flash the ISO like **Fedora Media Writer** ([**Windows/macOS**](https://github.com/FedoraQt/MediaWriter/releases) or [**Linux**](https://flathub.org/en/apps/org.fedoraproject.MediaWriter))
-    - Ventoy is **NOT** supported software for flashing the Bazzite ISO.
+  - Booting from a SD or microSD card may work, but not all firmware support this.
+- One of the following programs to flash/boot the ISO:
+  - **Fedora Media Writer (recommended)** ([Windows/macOS](https://github.com/FedoraQt/MediaWriter/releases), [Linux](https://flathub.org/en/apps/org.fedoraproject.MediaWriter))
+  - **Rufus** ([Windows](https://rufus.ie/))
+  - **Ventoy** ([Windows, Linux](https://www.ventoy.net/)) (note: Ventoy needs [**extra steps for Secure Boot Support to work**](https://www.ventoy.net/en/doc_secure.html))
 - A physical wired keyboard is **recommended** and **required for devices without a touchscreen**.
   - Otherwise, create a User Account with a **username** and a **user password** if you have a keyboard.
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
As of 4.14 update Rufus automatically picks DD image mode for Bazzite so no reason to do it manually.

The check was added in this commit https://github.com/pbatard/rufus/commit/8546656ee9d0a57233603af2b0941c6af2b291ab

Also syncing it with Legacy ISO guide