### PR TITLE
docs(nvidia): don't mention a resolution in gaming mode exclusive issue

### DIFF
--- a/src/Handheld_and_HTPC_edition/quirks.cs.md
+++ b/src/Handheld_and_HTPC_edition/quirks.cs.md
@@ -193,5 +193,5 @@ https://www.youtube.com/watch?v=gE1ff72g2Gk
 ## Exkluzivní problémy GPU Nvidia s herním režimem Steam
 
 - "Povolit GPU akcelerované vykreslování ve webových zobrazeních (vyžaduje restart)" musí být povoleno v nastavení Steam pro lepší výkon v uživatelském rozhraní.
-  - Rozlišení nad 2560x1440 způsobí při použití tohoto nastavení grafické artefakty, které zlomí hru.
+  - Zapnutí této možnosti s největší pravděpodobností způsobí grafické artefakty, které znemožní hraní.
 - HDR může způsobit herní grafické artefakty.

--- a/src/Handheld_and_HTPC_edition/quirks.md
+++ b/src/Handheld_and_HTPC_edition/quirks.md
@@ -193,5 +193,5 @@ https://www.youtube.com/watch?v=gE1ff72g2Gk
 ## Nvidia GPU Exclusive Issues with Steam Gaming Mode
 
 - "Enable GPU accelerated rendering in web views (requires restart)" must be enabled in the Steam settings for better performance in the UI.
-  - Resolutions above 2560x1440 will cause game-breaking graphical artifacts using this setting.
+  - Enabling this option will most likely cause game-breaking graphical artifacts.
 - HDR can cause game-breaking graphical artifacts.


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
This issue still appears, this time on any resolution now