### PR TITLE
docs(arctis manager):add uninstall instructions and autostart procedure

### DIFF
--- a/src/Advanced/arctis-manager.md
+++ b/src/Advanced/arctis-manager.md
@@ -12,6 +12,8 @@ search:
 
 # Installing Arctis Manager
 
+[![GitHub Release](https://img.shields.io/github/v/release/elegos/Linux-Arctis-Manager?label=Latest%20Release&color=brightgreen&logo=github&logoColor=white)](https://github.com/elegos/Linux-Arctis-Manager/releases)
+
 ## Purpose
 This guide walks you through installing [**Linux-Arctis-Manager**](https://github.com/elegos/Linux-Arctis-Manager) (v2.0.4+) using Distrobox. This method works without package layering or temporarily turning off the read-only root filesystem while providing the manager with necessary hardware access and background services. For a list of currently supported devices as well as advanced documentation, please check the linked repository.
 
@@ -31,5 +33,35 @@ curl -LsSf https://raw.githubusercontent.com/elegos/Linux-Arctis-Manager/refs/he
 To launch the system tray icon automatically on login, copy its desktop entry to your autostart folder:
 
 ```bash
-cp ~/.local/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
+ln -sf ~/.local/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
 ```
+
+## Uninstall / Cleanup
+1. Stop and disable the service:
+
+   ```bash
+   systemctl --user disable --now arctis-manager
+   rm ~/.config/systemd/user/arctis-manager.service
+   ```
+
+3. Remove the container:
+ 
+   ```bash
+   distrobox-rm -f arctis-manager
+   ```
+
+4. Remove leftover host files:
+
+   ```bash
+   # desktop menu entries
+   rm -f ~/.local/share/applications/ArctisManager.desktop
+   rm -f ~/.local/share/applications/ArctisManagerSystray.desktop
+   rm -f ~/.config/autostart/ArctisManagerSystray.desktop
+
+   # udev rules
+   sudo rm -f /etc/udev/rules.d/91-steelseries-arctis.rules
+
+   # user preferences and virtual environment
+   rm -rf ~/.config/arctis_manager
+   rm -rf ~/.local/share/pipx/venvs/linux-arctis-manager
+   ```   

--- a/src/Advanced/arctis-manager.md
+++ b/src/Advanced/arctis-manager.md
@@ -30,7 +30,7 @@ curl -LsSf https://raw.githubusercontent.com/elegos/Linux-Arctis-Manager/refs/he
     For Linux operating systems like Bazzite (image-based / read-only root filesystem), the app behaves like a native installation rather than an isolated container. Because Distrobox mounts your `/home`, `/var`, and `/etc` directly, the manager can interact with the system services and configuration files it needs to function.
 
 ### Enable Autostart (Optional)
-To launch the system tray icon automatically on login, copy its desktop entry to your autostart folder:
+To launch the system tray app automatically on login:
 
 ```bash
 ln -sf ~/.local/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
@@ -44,13 +44,13 @@ ln -sf ~/.local/share/applications/ArctisManagerSystray.desktop ~/.config/autost
    rm ~/.config/systemd/user/arctis-manager.service
    ```
 
-3. Remove the container:
+2. Remove the container:
  
    ```bash
    distrobox-rm -f arctis-manager
    ```
 
-4. Remove leftover host files:
+3. Remove leftover host files:
 
    ```bash
    # desktop menu entries

--- a/src/Advanced/arctis-manager.md
+++ b/src/Advanced/arctis-manager.md
@@ -26,15 +26,16 @@ curl -LsSf https://raw.githubusercontent.com/elegos/Linux-Arctis-Manager/refs/he
 ```
 
 !!! note
-    
+
     For Linux operating systems like Bazzite (image-based / read-only root filesystem), the app behaves like a native installation rather than an isolated container. Because Distrobox mounts your `/home`, `/var`, and `/etc` directly, the manager can interact with the system services and configuration files it needs to function.
 
-### Enable Autostart (Optional)
-To launch the system tray app automatically on login:
+!!! tip
 
-```bash
-ln -sf ~/.local/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
-```
+    To launch the system tray app automatically on login:
+
+    ```bash
+    ln -sf ~/.local/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
+    ```
 
 ## Uninstall / Cleanup
 1. Stop and disable the service:


### PR DESCRIPTION
added instructions to remove arctic manager distrobox and remaining host files, changed autostart behavior to use a symlink instead of static file copy so that it follows future .desktop file changes. Added version tracker badge