### PR TITLE
docs(sunshine): added alternative stable install section

### DIFF
--- a/src/Advanced/sunshine.md
+++ b/src/Advanced/sunshine.md
@@ -30,6 +30,33 @@ The guide below will walk you through switching to the Sunshine flatpak.
 The Bazzite Portal only helps you install and set up the stable Sunshine **flatpak** package. If you want to try a beta package for fixes to your system or due to other purposes, you will need to install it manually. 
 !!! info "Bazzite Portal retains the ability to install the **experimental** beta Sunshine **brew** package. However, it is known to have issues related to screen capture and Systray indicator."
 
+## Alternative Sunshine Installations
+
+Sunshine does provide a RPM (COPR) repository for their Fedora package. You may try to install Sunshine with alternative ways as listed below, albeit with some limitations.
+!!! warning "Installation of Sunshine via these methods is not officially supported. Please report issues with Sunshine to the main Sunshine repository, report issues with packaging to their respective packaging repositories."
+
+=== "Layering from the COPR"
+    
+    This is similar to the situation when sunshine is/was included in the image.
+    Layering the Sunshine package from the [official stable COPR](https://copr.fedorainfracloud.org/coprs/lizardbyte/stable/) by running
+    ```bash
+    sudo dnf5 copr enable lizardbyte/stable
+    rpm-ostree install Sunshine
+    ```
+    !!! info "Note that Sunshine does not maintain a stable version across major Fedora updates. It's likely that a new package for the next major update of Bazzite will be missing!. This will stop system updates from occurring until Sunshine provides an updated package. You will be asked to run `rpm-ostree reset` to remove all layered packages when this situation arises."
+
+=== "Layering a community maintained package"
+    
+    This is similar to the situation when sunshine is/was included in the image.
+    In contrast with the official Sunshine COPR, this repository will be maintained explicitly for Fedora and it will have an updated package for every major release of Sunshine and Bazzite. Breaking changes will be handled by the package and it is tested on Fedora and Bazzite to ensure a smooth upgrade.
+
+    Layering the Sunshine package from the [community maintained COPR](https://copr.fedorainfracloud.org/coprs/pvermeer/sunshine/) by running
+    ```bash
+    sudo dnf5 copr enable pvermeer/sunshine
+    rpm-ostree install sunshine
+    ```
+    !!! info "This community package is maintained by *pvermeer*, and is not officially endorsed, maintained, nor packaged by Bazzite."
+    
 ## Installing Sunshine Beta
 
 Sunshine does not provide a repository for their flatpak package. You may try to install Sunshine Beta with alternative ways as listed below, albeit with some limitations.

--- a/src/Advanced/sunshine.md
+++ b/src/Advanced/sunshine.md
@@ -43,7 +43,7 @@ Sunshine does provide an RPM (COPR) repository for their Fedora package. You may
     sudo dnf5 copr enable lizardbyte/stable
     rpm-ostree install Sunshine
     ```
-    !!! info "Note that Sunshine does not maintain a stable version across major Fedora updates. It's likely that a new package for the next major update of Bazzite will be missing!. This will stop system updates from occurring until Sunshine provides an updated package. You will be asked to run `rpm-ostree reset` to remove all layered packages when this situation arises."
+    !!! info "Note that Sunshine does not maintain a stable version across major Fedora updates. It's likely that a new package for the next major update of Bazzite will be missing! This will stop system updates from occurring until Sunshine provides an updated package. You will be asked to run `rpm-ostree reset` to remove all layered packages when this situation arises."
 
 === "Layering a community maintained package"
     

--- a/src/Advanced/sunshine.md
+++ b/src/Advanced/sunshine.md
@@ -47,7 +47,7 @@ Sunshine does provide an RPM (COPR) repository for their Fedora package. You may
 
 === "Layering a community maintained package"
     
-    This is similar to the situation when sunshine is/was included in the image.
+    This is similar to the situation when Sunshine is/was included in the image.
     In contrast with the official Sunshine COPR, this repository will be maintained explicitly for Fedora and it will have an updated package for every major release of Sunshine and Bazzite. Breaking changes will be handled by the package and it is tested on Fedora and Bazzite to ensure a smooth upgrade.
 
     Layering the Sunshine package from the [community maintained COPR](https://copr.fedorainfracloud.org/coprs/pvermeer/sunshine/) by running

--- a/src/Advanced/sunshine.md
+++ b/src/Advanced/sunshine.md
@@ -32,7 +32,7 @@ The Bazzite Portal only helps you install and set up the stable Sunshine **flatp
 
 ## Alternative Sunshine Installations
 
-Sunshine does provide a RPM (COPR) repository for their Fedora package. You may try to install Sunshine with alternative ways as listed below, albeit with some limitations.
+Sunshine does provide an RPM (COPR) repository for their Fedora package. You may try to install Sunshine with alternative ways as listed below, albeit with some limitations.
 !!! warning "Installation of Sunshine via these methods is not officially supported. Please report issues with Sunshine to the main Sunshine repository, report issues with packaging to their respective packaging repositories."
 
 === "Layering from the COPR"

--- a/src/Advanced/sunshine.md
+++ b/src/Advanced/sunshine.md
@@ -37,7 +37,7 @@ Sunshine does provide an RPM (COPR) repository for their Fedora package. You may
 
 === "Layering from the COPR"
     
-    This is similar to the situation when sunshine is/was included in the image.
+    This is similar to the situation when Sunshine is/was included in the image.
     Layering the Sunshine package from the [official stable COPR](https://copr.fedorainfracloud.org/coprs/lizardbyte/stable/) by running
     ```bash
     sudo dnf5 copr enable lizardbyte/stable


### PR DESCRIPTION
Hi there, maintainer of pvermeer/sunshine COPR here.

It's come to my attention that these docs for Sunshine are linking to the beta version of this COPR. As I, and the Sunshine devs would absolutely not recommend to use the beta version unless you're testing things or really need a new feature. I would like to add information about the stable versions before mentioning the beta versions since stable is highly recommended.

The beta version that I publish is not tested at all and will cause the same issues Bazzite experienced from time to time. I only fix build issues there since the Sunshine maintainter has a habit of constantly changing the build system and I'm not gonna test this all the time. I just want to keep ahead of build issues for when a new stable is released.

I also noticed (reddit etc...) that users are under the impression that beta is the way to go, while the stable build works just fine for them. So adding this before mentioning beta would be great.

I would even suggest not mentioning beta at all since user who want to use this should already know how to install it, and possibly fix issues.

Thanks!