### PR TITLE
docs(zh_HK): Add initial translations for zh_HK

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,81 @@ plugins:
           build: true
         - locale: cs
           name: Čeština
-          build: true          
+          build: true
+        - locale: zh_HK
+          name: 中文（香港）
+          build: true
+          site_name: Bazzite 指南
+          theme:
+            language: zh-Hant
+          nav:
+            - 主頁: index.md
+            - 常見問題: "General/FAQ.md"
+            - 安裝指南:
+                - "安裝 Bazzite": General/Installation_Guide/index.md
+                - "安裝教學": General/Installation_Guide/install-guide.md
+                - "安裝後設定": General/Installation_Guide/post-installation.md
+                - "安裝疑難排解": General/Installation_Guide/troubleshoot_guide.md
+                - "舊版ISO安裝教學": General/Installation_Guide/legacy-install.md
+                - "備用安裝辦法": General/Installation_Guide/alternate-install-guide.md
+            - 遊戲指南:
+                - "遊戲簡介": Gaming/index.md
+                - "硬體相容性": Gaming/Hardware_compatibility_for_gaming.md
+            - Bazzite掌機版(Bazzite-Deck):
+                - "Bazzite掌機版教學": Handheld_and_HTPC_edition/index.md
+                - "Bazzite掌機版概覽": Handheld_and_HTPC_edition/Steam_Gaming_Mode.md
+                - "Steam遊戲模式的常見問題與解決辦法": Handheld_and_HTPC_edition/quirks.md
+                - "掌機相容性":
+                    - Handheld_and_HTPC_edition/Handheld_Wiki/index.md
+                    - "華碩": Handheld_and_HTPC_edition/Handheld_Wiki/ASUS_ROG_Ally.md
+                    - "聯想": Handheld_and_HTPC_edition/Handheld_Wiki/Lenovo_Legion_Go.md
+                    - "GPD": Handheld_and_HTPC_edition/Handheld_Wiki/GPD_Handhelds.md
+                    - "OneXPlayer": Handheld_and_HTPC_edition/Handheld_Wiki/OneXPlayer_Handhelds.md
+                    - "Ayn": Handheld_and_HTPC_edition/Handheld_Wiki/Ayn_Handhelds.md
+                    - "Ayaneo": Handheld_and_HTPC_edition/Handheld_Wiki/Ayaneo_Handhelds.md
+                    - "Steam Deck": Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.md
+                    - "其他掌機": Handheld_and_HTPC_edition/Handheld_Wiki/Other_Handhelds.md
+            - 軟件:
+                - "安裝及管理軟件":
+                    - Installing_and_Managing_Software/index.md
+                    - "Bazzite軟件安裝概覽": Installing_and_Managing_Software/software-intro.md
+                    - "Bazzite Portal": Installing_and_Managing_Software/Bazzite_Portal.md
+                    - "ujust 命令行指令": Installing_and_Managing_Software/ujust.md
+                    - "Bazaar 應用程式商店": Installing_and_Managing_Software/Flatpak.md
+                    - "Homebrew": Installing_and_Managing_Software/Homebrew.md
+                    - "容器":
+                        - Installing_and_Managing_Software/Containers.md
+                        - "Distrobox": Installing_and_Managing_Software/Distrobox.md
+                        - "Quadlet": Installing_and_Managing_Software/Quadlet.md
+                    - "Appimage": Installing_and_Managing_Software/AppImage.md
+                    - "rpm-ostree": Installing_and_Managing_Software/rpm-ostree.md
+                    - "Waydroid 設置教程": Installing_and_Managing_Software/Waydroid_Setup_Guide.md
+                - "系統更新與回溯":
+                    - "Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/index.md"
+                    - "系統更新教程": "Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/updating_guide.md"
+                    - "回溯系統更新": "Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rolling_back_system_updates.md"
+                    - "切換更新頻道": "Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide.md"
+                    - "Bazzite更新助手(bazzite-rollback-helper)": "Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/bazzite_rollback_helper.md"
+            - 進階指南:
+                - "目錄": Advanced/index.md
+                - "設置硬盤自動掛載": Advanced/Auto-Mounting_Secondary_Drives.md
+                - "使用ScopeBuddy管理Gamescope渲染器": Advanced/scopebuddy.md
+                - "自定義解像度": Advanced/custom_resolution.md
+                - "Bazzite 命令行工具": Advanced/bazzite-cli.md
+                - "Looking-Glass指南": Advanced/looking-glass.md
+                - "系統殼層(Shell)設置須知": Advanced/Best_Shell_Practices.md
+                - "重啟至系統救援模式(Rescue Mode)": Advanced/rescue-and-emergency-mode.md
+                - "重置用戶密碼": Advanced/Reset_Forgotten_User_Password.md
+                - "設置系統內存分頁以擴展內存及啟用休眠模式": Advanced/swapfile.md
+                - "系統啟動時顯示日誌輸出": Advanced/plymouth_init.md
+                - "使用Sunshine進行遊戲串流": Advanced/sunshine.md
+                - "如何更改Initramfs和Dracut": Advanced/dracut-and-initramfs.md
+                - "創建自定義Bazzite系統映像檔": Advanced/creating_custom_image.md
+            - Bazzite-DX: https://dev.bazzite.gg
+            - 合作與貢獻: https://universal-blue.org/contributing.html
+            - 社群: community.md
+            - 捐款: donations.md
+            - 下載: https://bazzite.gg/#image-picker
 
   - search
   - macros:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,20 @@ plugins:
                 - "安裝疑難排解": General/Installation_Guide/troubleshoot_guide.md
                 - "舊版ISO安裝教學": General/Installation_Guide/legacy-install.md
                 - "備用安裝辦法": General/Installation_Guide/alternate-install-guide.md
+            - 常用指南:
+                - "常用教學": General/index.md
+                - "用語和詞庫": General/terms.md
+                - "Bazzite與Fedora原子化發行版": General/Fedora_Atomic_Comparison.md
+                - "對比SteamOS": "General/SteamOS_Comparison.md"
+                - "桌面環境個人化、主題與其他設置": General/Desktop_Environment_Tweaks.md
+                - "使用VPN": General/VPN.md
+                - "疑難排解": "General/issues_and_resolutions.md"
+                - "提交Bug報告": General/reporting_bugs.md
+                - "社區資源": General/community-links.md
+                - "安全性政策": https://github.com/ublue-os/bazzite/blob/main/SECURITY-ZH-TW.md
+                - "許可證(License)": https://github.com/ublue-os/bazzite/blob/main/LICENSE
+                - "新聞資料包": https://github.com/ublue-os/bazzite/tree/main/press_kit
+                - "卸載Bazzite": General/uninstalling-bazzite.md
             - 遊戲指南:
                 - "遊戲簡介": Gaming/index.md
                 - "硬體相容性": Gaming/Hardware_compatibility_for_gaming.md

--- a/src/General/Desktop_Environment_Tweaks.md
+++ b/src/General/Desktop_Environment_Tweaks.md
@@ -24,31 +24,18 @@ Step-by-step instructions to install custom themes on KDE Plasma.
 
 ## Theme Extraction Locations
 
-The location where specific KDE Plasma components will be extracted on the desktop.
+A list of theme extraction locations are shown below: <small>(_You may need to create these folders manually._)</small>
 
-### Global Themes
+-   Global Themes: `~/.local/share/plasma/look-and-feel/`
+-   Plasma Themes: `~/.local/share/plasma/desktoptheme/`
+-   Plasma Window Decorations: `~/.local/share/aurorae/themes/`
+-   Icon / Cursor Themes: `~/.local/share/icons`
+-   Sounds: `~/.local/share/sounds`
+-   Login Screen: Security & Privacy → Login Screen
 
-Global themes are placed in `~/.local/share/plasma/look-and-feel/`. <small>(_You may need to make this directory_.)</small>
-
-### Plasma Themes
-
-"Plasma themes" are placed in `~/.local/share/plasma/desktoptheme/`. <small>(_You may need to make this directory_.)</small>
-
-### Plasma Window Decorations
-
-"Window decoration themes" are placed in `~/.local/share/aurorae/themes/`. <small>(_You may need to make this directory_.)</small>
-
-### Icon / Cursor Themes
-
-"Icon/Cursor themes" are placed in `~/.local/share/icons`. <small>(_You may need to make this directory_.)</small>
-
-### Sounds
-
-System sounds can be replaced in `~/.local/share/sounds`. <small>(_You may need to make this directory_.)</small>
-
-### SDDM (Login Manager) Themes
-
-SDDM themes can be layered **at your own risk** if they are available as RPM packages using [`rpm-ostree`](/Installing_and_Managing_Software/rpm-ostree.md).
+!!! notice
+    
+    Bazzite has switched to KDE Display Manager to manage logins after updating to Fedora 44.
 
 ## Application Permissions to Use Themes
 
@@ -64,10 +51,16 @@ The default desktop environment for Bazzite is KDE Plasma which also happens to 
 
 ### Manage GNOME Extensions (`-gnome` Images)
 
-The "Extension Manager" application allows for installing new extensions to GNOME and managing currently pre-installed extensions.  Proceed with caution as extensions can make your system unstable and if your desktop crashes then GNOME will disable all of the extensions on the next boot.
+!!! warning
+
+    Proceed with caution, as extensions can make your system unstable and if your desktop crashes, then GNOME will disable all extensions on the next boot.
+
+The "Extension Manager" application allows for installing new extensions to GNOME and managing currently pre-installed extensions.
 
 ### Steam Gaming Mode Customization (`-deck` Images)
+
 !!! warning
+
     Decky Loader will sometimes have issues with new Steam and Gamescope updates, and may need to be uninstalled temporarily.
 
 Install [Decky Loader](https://decky.xyz/) then install [CSS Loader](https://docs.deckthemes.com/) to customize how Steam Gaming Mode looks. Be aware that third-party plugins may cause issues. Read [Bazzite's Steam Gaming Mode quirks documentation](../Handheld_and_HTPC_edition/quirks.md) to resolve common issues if you run into them after using Decky Loader.

--- a/src/General/Desktop_Environment_Tweaks.zh_HK.md
+++ b/src/General/Desktop_Environment_Tweaks.zh_HK.md
@@ -1,0 +1,70 @@
+---
+title: Desktop Environment Customization, Themes, and Tweaks
+---
+
+# 桌面環境個人化、主題與其他設置
+
+!!! warning
+    
+    個人化插件及主題有機會降低系統穩定性，**安裝風險自負**！
+
+## 在KDE Plasma上使用個人化主題
+
+KDE Plasma是Bazzite的預設桌面環境，亦是Linux生態中包含最多個人化設置的桌面環境<small>(_當然，你也可以在自定義系統映像檔中遊玩各種窗口管理器(Window Manager)，它們有更多、更複雜的個人化設置_)</small>。你可以在Plasma的設定程式中安裝由社區製作的自定義主題、鼠標圖案、系統圖示。這些主題會被安裝於`~/.local/share/plasma`目錄下並自動管理和分類；但有的時候你需要人手將有問題的主題或插件移除。
+
+![Directory|401x207, 75%](../img/Directory.png)
+
+## 手動安裝系統主題
+
+1. 在[**KDE Store**](https://store.kde.org/browse/)中下載主題的壓縮檔
+2. 將其解壓縮至`~/.local/share/plasma/` <small>(_你或須手動創建此文件夾_)</small>
+3. 打開系統設定，並選擇你的主題、應用程式風格、鼠標圖案、或其他個人化設置
+
+## 個人化設置的解壓縮路徑
+
+以下為各種個人化設置的存取位置<small>(_你或須手動創建這些文件夾_)</small>
+
+-   Global Themes（全域主題）: `~/.local/share/plasma/look-and-feel/`
+-   Plasma Themes（Plasma主題）: `~/.local/share/plasma/desktoptheme/`
+-   Plasma Window Decorations（Plasma窗口裝飾）: `~/.local/share/aurorae/themes/`
+-   Icon / Cursor Themes（鼠標圖案／系統圖示）: `~/.local/share/icons`
+-   Sounds(系統音效）: `~/.local/share/sounds`
+-   Login Screen（登入畫面設置）: Security & Privacy → Login Screen
+
+!!! notice 
+    
+    Bazzite於更新至Fedora 44之後已轉用全新的KDE Display Manager作為登入管理器。
+
+## Flatpak應用權限和主題
+
+一些Flatpak應用程式需額外設置一些目錄的唯讀權限以使鼠標圖案於應用內生效。
+
+**例子**： `~/.local/share/icons/:ro`
+
+<hr>
+
+## 其他桌面環境的個人化設置
+
+上文提及，KDE Plasma是Linux中包含最多個人化設置的桌面環境，因此此指南主要包含Plasma的個人化設定。
+
+### 管理 GNOME 插件 (`-gnome` 映像及更新頻道)
+
+你可以在「Extension Manager」（插件管理器）中安裝及管理預安裝和新的插件。
+
+!!! warning
+    
+    若GNOME崩潰，其所有插件會將被自動關閉。此外，GNOME一向對插件的支持都不太友好，其在各版本更新中有不少的機率使現有插件停止運作。
+
+### Steam 遊戲模式個人化設置 (`-deck` 映像及更新頻道)
+!!! warning
+
+    Decky Loader 或許會因新Steam及Gamescope版本而出現問題，你或須將其暫時卸載。
+
+安裝 [Decky Loader](https://decky.xyz/) 和 [CSS Loader](https://docs.deckthemes.com/) 以對Steam遊戲模式的介面進行個人化修改。 注意第三方插件有機會降低系統穩定性。你可於[此處](../Handheld_and_HTPC_edition/quirks.md)尋找常見問題的解決方法。
+
+<hr>
+
+## 桌面環境文檔及指南
+- [**KDE Plasma 文檔**](https://docs.kde.org/stable5/en/plasma-desktop/plasma-desktop/index.html)
+- [**GNOME 文檔**](https://help.gnome.org/users/gnome-help/stable/)
+- [**Bazzite Steam遊戲模式指南**](../Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)

--- a/src/General/Desktop_Environment_Tweaks.zh_HK.md
+++ b/src/General/Desktop_Environment_Tweaks.zh_HK.md
@@ -1,5 +1,5 @@
 ---
-title: Desktop Environment Customization, Themes, and Tweaks
+title: 桌面環境個人化、主題與其他設置
 ---
 
 # 桌面環境個人化、主題與其他設置
@@ -28,7 +28,7 @@ KDE Plasma是Bazzite的預設桌面環境，亦是Linux生態中包含最多個�
 -   Plasma Themes（Plasma主題）: `~/.local/share/plasma/desktoptheme/`
 -   Plasma Window Decorations（Plasma窗口裝飾）: `~/.local/share/aurorae/themes/`
 -   Icon / Cursor Themes（鼠標圖案／系統圖示）: `~/.local/share/icons`
--   Sounds(系統音效）: `~/.local/share/sounds`
+-   Sounds（系統音效）: `~/.local/share/sounds`
 -   Login Screen（登入畫面設置）: Security & Privacy → Login Screen
 
 !!! notice 

--- a/src/General/FAQ.md
+++ b/src/General/FAQ.md
@@ -25,21 +25,15 @@ Bazzite offers multiple images, but most images will be following _one of these 
 
 ### 1. Desktop Edition
 
-<sub>(**Variant 1**)</sub>
-
 **Steam Gaming Mode is not on these specific images!**
 
 Intended specifically for desktops and laptops with a focus on gaming which is influenced by SteamOS's Desktop Mode and the maintenance-free nature of ChromeOS. A gaming-focused Fedora Atomic Desktop (Kinoite/Silverblue) operating system.  Steam and other gaming utilities are part of the base operating system. System rollbacks available with a rock-solid stable Fedora Linux base. Most modern PC hardware should be compatible outside of specific drivers that do not work well on desktop Linux.  [Flathub](https://flathub.org/) is enabled out of the box, so all of the applications that you would find on SteamOS are available on Bazzite.  System and application updates are automatically downloaded in the background and applied on a restart by default.
 
-### [2. Bazzite-Deck Edition](../Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)
-
-<sub>(**Variant 2**)</sub>
+### [2. Handheld Edition (Bazzite-Deck)](../Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)
 
 "**Steam Gaming Mode**" is pre-installed and its features fully functional for supported hardware. This version of Bazzite boots directly into the Steam Gaming Mode session and is intended for handhelds and couch-gaming scenarios. It also includes a Desktop Mode session. System and application updates are manually upgraded in Steam Gaming Mode and applied on a reboot.
 
 ### [3. Bazzite-DX (Developer eXperience Edition)](https://dev.bazzite.gg/)
-
-<sub>(**Variant 3**)</sub>
 
 A version of Bazzite that specifically caters to software development. It is not installed via an ISO; instead, you switch to it by rebasing from your current image to a Bazzite-DX image.
 
@@ -47,7 +41,7 @@ A version of Bazzite that specifically caters to software development. It is not
 
 !!! note
 
-    This does not include all of the Bazzite images.
+    This is not an exhaustive list.
 
 Verify your Bazzite image by entering this **command** in the terminal:
 
@@ -58,20 +52,20 @@ rpm-ostree status
 !!! important
 
     Every Bazzite image should start with `ostree-image-signed:docker://ghcr.io/ublue-os/...`.
-    <sub> The `...` is a placeholder for the actual image name which can be referenced in the chart below. </sub>
+    <sub> The `...` is a placeholder for the actual **image name** which can be referenced in the chart below. </sub>
 
-| Image                       | Desktop Environment | Steam Gaming Mode | Hardware                                 | Edition       |
+| **Image Name**              | Desktop Environment | Steam Gaming Mode | Hardware                                 | Edition       |
 | --------------------------- | ------------------- | ----------------- | ---------------------------------------- | ------------- |
 | `bazzite`                   | KDE Plasma          | No                | AMD/Intel GPUs                           | Desktop       |
 | `bazzite-nvidia`            | KDE Plasma          | No                | Nvidia GPUs                              | Desktop       |
-| `bazzite-nvidia-open`            | KDE Plasma          | No                | Nvidia GPUs (Newer Nvidia GPUs)                             | Desktop       |
+| `bazzite-nvidia-open`       | KDE Plasma          | No                | Nvidia GPUs (Newer Nvidia GPUs)          | Desktop       |
 | `bazzite-gnome`             | GNOME               | No                | AMD/Intel GPUs                           | Desktop       |
 | `bazzite-gnome-nvidia`      | GNOME               | No                | Nvidia GPUs                              | Desktop       |
-| `bazzite-gnome-nvidia-open`      | GNOME               | No                | Nvidia GPUs (Newer Nvidia GPUs)                            | Desktop       |
-| `bazzite-deck`              | KDE Plasma          | Yes               | AMD/Intel Arc GPUs                       | Bazzite-Deck |
-| `bazzite-deck-nvidia`              | KDE Plasma          | Yes               | Nvidia GPUs (Newer Nvidia GPUs)                       | Bazzite-Deck |
-| `bazzite-deck-nvidia-gnome`              | GNOME          | Yes               | Nvidia GPUs (Newer Nvidia GPUs)                       | Bazzite-Deck |
-| `bazzite-deck-gnome`        | GNOME               | Yes               | AMD/Intel Arc GPUs                       | Bazzite-Deck |
+| `bazzite-gnome-nvidia-open` | GNOME               | No                | Nvidia GPUs (Newer Nvidia GPUs)          | Desktop       |
+| `bazzite-deck`              | KDE Plasma          | Yes               | AMD/Intel Arc GPUs                       | Handheld      |
+| `bazzite-deck-nvidia`       | KDE Plasma          | Yes               | Nvidia GPUs (Newer Nvidia GPUs)          | Handheld      |
+| `bazzite-deck-nvidia-gnome` | GNOME               | Yes               | Nvidia GPUs (Newer Nvidia GPUs)          | Handheld      |
+| `bazzite-deck-gnome`        | GNOME               | Yes               | AMD/Intel Arc GPUs                       | Handheld      |
 
 ## SteamOS is based on Arch Linux, so why use Fedora Atomic Desktop?
 
@@ -90,11 +84,12 @@ Since Bazzite is a custom Fedora Atomic Desktop image, it makes use of read-only
 
 ## Are AMD and Intel graphics card drivers pre-installed?
 
-**Yes** and they are updated during a system upgrade when new drivers are available. It is not possible to manually update them separately as they are part of the image.
+**Yes**. Most hardware drivers are integrated into the upstream Linux kernel and updated with it, and the kernel is updated as part of Bazzite's system image. When using Bazzite images, it is not possible to manually change driver or kernel versions; on the flip side, every single Bazzite image is tested to make sure the combination of kernel patches, software, and runtimes works and shipped to your system.
 
 ### Are Nvidia graphics card drivers pre-installed?
 
 **Yes, on the Nvidia images** and they are updated during a system upgrade when new drivers are available. It is not possible to manually update them.
+
 - The legacy (`-nvidia`) image supports Pascal, Maxwell, and Volta architectures (GTX 900, GTX 1000, Nvidia Titan V, GTX 750 (TI) and GTX 745).
 - The modern (`-nvidia-open`) image supports every Nvidia card from the Turing architecture and newer (GTX 16 and all RTX cards).
 
@@ -103,10 +98,15 @@ Since Bazzite is a custom Fedora Atomic Desktop image, it makes use of read-only
 #### Will support for much older Nvidia graphics cards be added?
 
 There are currently no plans to support Kepler and older architectures (Most GTX 700 cards and older) since they are **no longer supported** by the upstream Nvidia drivers.
-- You can still install Bazzite, using the open-source nouveau driver.
-    - However, the performance and stability of this driver lags behind the official Nvidia drivers.
-- It is **not possible** to manually install the proprietary Nvidia drivers for your older card in Bazzite.
--     You would need a different Linux distribution that allows for such, if you wish to use the proprietary Nvidia drivers for your GPU.
+
+-   You can still install Bazzite, using the open-source `nouveau` driver.
+    -   However, the performance and stability of this driver lags behind the official Nvidia drivers as the open source driver cannot communicate with the closed source GSP firmware, causing the card to be stuck at its lowest clocks.
+-   It is **not possible** to manually install the proprietary Nvidia drivers for your older card in Bazzite.
+-   You would need a different Linux distribution that allows for such, if you wish to use the proprietary Nvidia drivers for your GPU. Support for these cards are essentially cut off by Nvidia on Fedora based distributions.
+
+!!! info
+
+    Nvidia only started initial support for the Wayland protocol at version 495, while the last driver to support Kepler or older cards was version 470. Bazzite does not support running the legacy X11 display server. If you need to run games on these graphics cards, try other Linux distributions such as Linux Mint and Debian.
 
 ### What if I change hardware?
 
@@ -122,21 +122,30 @@ This warning occurs on the [Desktop Edition](#1-desktop-edition) because it auto
 
 ![](/../img/gpu_driver_warning.png)
 Windows games cannot correctly detect Linux graphics drivers.
-- Because the version numbers are different between the Windows and Linux drivers, games will occasionally warn you about outdated drivers.
-- **You can safely ignore any such warning.**
-- [Please see here for more details.](#are-amd-and-intel-graphics-card-drivers-pre-installed)
+
+-   Because the version numbers are different between the Windows and Linux drivers, games will occasionally warn you about outdated drivers.
+-   **You can safely ignore any such warning.**
+-   [Please see here for more details.](#are-amd-and-intel-graphics-card-drivers-pre-installed)
 
 ## Does Bazzite support CSM/Legacy Boot?
 
 No. A notification with instructions on turning off CSM will occur when the installer detects Legacy BIOS boot: ![CSM](../img/csm.webp)
 
-## Am I able to use AMD Fluid Motion Frames?
+## Am I able to use Frame Generation technologies such as AFMF and FSR-FG?
 
-**Yes**, but only if the game supports it. It's not available globally for every game like on Windows, but:
-* There may be individual game mods or [Decky plugins](https://github.com/xXJSONDeruloXx/Decky-Framegen) that mimic similar functionality.
-* If you own [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) on Steam, you can set up a LSFG Vulkan layer with the `ujust get-lsfg` terminal command.
+**Yes**, but only if the game supports FSR3.1 or newer. Note that:
+
+-   In open source drivers, there are no driver-level frame generation similar to AFMF.
+-   There may be individual game mods or [Decky plugins](https://github.com/xXJSONDeruloXx/Decky-Framegen) that mimic similar functionality.
+-   When using `Proton-CachyOS 11.0-20260702` or its derivatives, games that support FSR3.1+ will be automatically upgraded to FSR4.1.1(see [Proton-CachyOS's GitHub Releases Page](https://github.com/CachyOS/proton-cachyos/releases/tag/cachyos-11.0-20260702-slr)). Additionally, **Bazzite Portal** allows you to toggle the FSR-MLFG workaround for RDNA3 GPUs.
+* If you own [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) on Steam, you can set up a LSFG Vulkan layer with its respective entry in **Bazzite Portal**.
 
 ## Can I theme my GRUB/bootloader?
+
+!!! note
+    
+    GRUB is hidden by default on Bazzite.
+    
 Theming the bootloader (GRUB) is unsupported by Bazzite and can cause critical issues such as your system not booting. Please remove any GRUB themes before reporting issues.
 
 ## Can I change the hostname of my device?
@@ -153,16 +162,17 @@ hostnamectl hostname <hostname>
 
 Specify a hostname where `<hostname>` is.
 
-
 ## I installed Windows but Bazzite won't boot { id="windows-bootloader-override" }
 
-Flash the Bazzite Live ISO to a thumb drive, and run the **Bazzite Bootloader Restoration Tool**.
+Flash the Bazzite Live ISO to a thumb drive, boot into it, and run the **Bazzite Bootloader Restoration Tool**.
 
 ## Can I switch to a different desktop environment on my current installation?
 
 <sub> (Example: Swapping from KDE Plasma to GNOME or vice-versa) </sub>
 
-It is **not recommended to switch between desktop environments** due to configuration files having different standards **which usually lead to broken installations after rebasing to a different Bazzite image with a different desktop environment installed**.
+It is **not recommended to switch between desktop environments** due to configuration files having different standards **which usually lead to broken installations after rebasing to a different Bazzite image with a different desktop environment installed**. You may try [Mending Wall](https://flathub.org/en/apps/org.indii.mendingwall), which helps manage these configuration files, at your own risk.
+
+The safest, and the only way to switch desktop environments that we recommend, is to backup your personal files and reinstall Bazzite.
 
 ## Am I able to install _this_ desktop environment or _that_ window manager?
 

--- a/src/General/FAQ.zh_HK.md
+++ b/src/General/FAQ.zh_HK.md
@@ -1,0 +1,208 @@
+---
+title: Frequently Asked Questions
+---
+
+# 常見問題 (FAQ)
+
+## Bazzite的目標受眾
+
+-   追求以運行遊戲為重點、類SteamOS用戶介面、低維護成本的用家
+-   需要一個介面對控制器／手柄友好，構建電腦影院的發燒友
+-   想在掌上型電腦／掌機上逃離Windows，但其裝置在SteamOS上運行時或有問題、缺失功能的遊戲愛好者
+-   想安裝類SteamOS作業系統，但能更快地獲得更新的系統包、內核，而又擁有原子化更新的網友<small>(_既要又要還要這一塊，那還説啥呢？都給你了，還不快裝？_)</small>
+
+## 我應安裝哪一個Bazzite版本？
+
+Bazzite的[網址](https://bazzite.gg/#image-picker)提供一個幫你治理選擇困難症的小工具，快去用吧！
+
+我們在不同版本的基礎上大致能將它們分為**三（3）大類**:
+
+- **1.  桌面版**: 不包含Steam遊戲模式，但仍有各種如Steam等的預安裝軟件，以桌面電腦為本的映像
+- **2.  掌機版**: 包含Steam遊戲模式，且預設啟動為遊戲模式，主要為控制器／手柄用家而設的類SteamOS映像
+- **3.  開發者版**: 預安裝VS Code、Docker，為開發者而設的映像
+
+### 1.  桌面版
+
+**此版本不包含Steam遊戲模式！**
+
+桌面版Bazzite作業系統。自動更新預設為開啟，為目前運行Windows的電腦之平替系統。
+
+### [2.  掌機版(Bazzite-Deck Edition)](../Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)
+
+包含Steam遊戲模式，預設啟動為遊戲模式<small>(_當然，你也可以進入Steam桌面模式！在桌面版裏的所有功能，這裏也有！_)</small>，主要為控制器／手柄用家而設，自動更新功能預設為**關**。
+
+### [3.  開發者版 (Bazzite-DX/Developer eXperience Edition)](https://dev.bazzite.gg/)
+
+特別為開發者而設的版本。此版本不設獨立ISO，你需要[切換更新頻道](/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide)以安裝此版本。
+
+<hr>
+
+## Bazzite版本列表範例
+
+!!! 溫馨提示
+
+    此列表不包含所有Bazzite映像！
+
+你可以使用以下命令行指令查找你目前系統的映像／更新頻道：
+
+```
+rpm-ostree status
+```
+
+!!! 重要事宜
+
+    所有Bazzite映像皆以`ostree-image-signed:docker://ghcr.io/ublue-os/...`開頭。<sub> 將 `...` 替換為以下列表範例中的**映像名稱** </sub>
+
+| **映像名稱**                 | 桌面環境             | Steam遊戲模式      | 目標硬件                                   | 類別          |
+| --------------------------- | ------------------- | ----------------- | ---------------------------------------- | ------------- |
+| `bazzite`                   | KDE Plasma          | 無                | AMD/Intel 顯卡                           | 桌面版       |
+| `bazzite-nvidia`            | KDE Plasma          | 無                | Nvidia 顯卡                              | 桌面版       |
+| `bazzite-nvidia-open`            | KDE Plasma          | 無                | Nvidia 顯卡 (GTX16+)                             | 桌面版       |
+| `bazzite-gnome`             | GNOME               | 無                | AMD/Intel 顯卡                           | 桌面版       |
+| `bazzite-gnome-nvidia`      | GNOME               | 無                | Nvidia 顯卡                              | 桌面版       |
+| `bazzite-gnome-nvidia-open`      | GNOME               | 無                | Nvidia 顯卡 (GTX16+)                            | 桌面版       |
+| `bazzite-deck`              | KDE Plasma          | 有               | AMD/Intel Arc 顯卡                       | 掌機版 |
+| `bazzite-deck-nvidia`              | KDE Plasma          | 有               | Nvidia 顯卡 (GTX16+)                       | 掌機版 |
+| `bazzite-deck-nvidia-gnome`              | GNOME          | 有               | Nvidia 顯卡 (GTX16+)                       | 掌機版 |
+| `bazzite-deck-gnome`        | GNOME               | 有               | AMD/Intel Arc 顯卡                       | 掌機版 |
+
+## 既然SteamOS基於Arch Linux，那為甚麼Bazzite要基於Fedora原子發行版？
+
+雖然SteamOS基於Arch Linux－一類滾動更新的發行版，但其系統包、內核、及驅動更新均較為老舊。你可以理解為SteamOS的各個版本（3.8、3.9等）都是Arch Linux在某一時間的鏡像。
+反之，Bazzite基於Fedora－一個採用**點更新模式**的發行版<small>(_而且Fedora一向都是更新較快的發行版_)</small>，並緊隨上游更新。這意味着Bazzite的系統已經經過上游的測試，而各包版本、內核、和驅動都能採用最新的上游版本。
+
+**Bazzite的目標是一個裝完就可以立即運行遊戲，毋須額外設置的作業系統。**
+
+### Bazzite基於Fedora原子發行版有甚麼優勢？
+
+由於Bazzite是一個基於Fedora原子發行版的映像，所以我們可以以唯讀方式將Bazzite作為[**可啟動容器**](https://containers.github.io/bootable/)安裝，享受以下優勢：
+
+-   系統無法啟動的風險微乎其微
+-   具自動化和簡易地回溯系統映像的能力
+-   類似於Android無縫更新的功能：所有更新都在系統正常運作時進行，無論更新多大都毋須進入特別的「Please do not turn off your PC」更新模式
+-   推動用戶層安裝包概念：應用程式不能更改系統文件
+
+> 按[這裏](https://universal-blue.org)前往UniversalBlue獲取更多資訊！
+
+## 我需要額外安裝AMD/Intel的顯卡驅動程式嗎？
+
+**不需要**。在Linux的生態中，AMD、Intel、和其他開源的驅動程式都匯集在上游Linux內核之中。驅動程式會隨著內核版本更新，而內核則會包含在Bazzite的映像裏更新。在使用官方Bazzite映像時，你不能更改系統中的驅動程式和內核版本；反之，Bazzite的每一次更新都會確保發行的驅動程式和內核都沒有問題。
+
+### 我需要額外安裝Nvidia的顯卡驅動嗎？
+
+**不需要**。雖然Nvidia的Linux驅動不跟隨上游Linux內核發佈和更新，但Bazzite依舊會將其打包進系統映像之中。正如上文所提，在使用官方Bazzite映像時，你不能更改映像中的驅動程式；反之，Bazzite的每一次更新都會確保驅動程式的運行沒有問題。此外，因為Nvidia不再為GTX10系列及以前的顯卡提供新版本的驅動程式，Bazzite提供兩種Nvidia映像：
+
+-   舊版（`-nvidia`）映像，採用最後支持Pascal（GTX10）、Maxwell(GTX900、GTX750&745)、和Volta(Titan V)架構的`580`系列驅動程式。
+-   新版（`-nvidia-open`）映像。因Nvidia於新版驅動程式將其部分開源化故得其名。此驅動程式支持Turing架構以後的所有Nvidia顯卡（即GTX16系列及所有RTX系列顯卡）。
+
+!!! 重要事宜 "倘若你發現你的Nvidia顯卡未能在Bazzite上正常運作，請確保你正在使用[正確的映像](./#bazzite_2)；以及[Nvidia Flatpak運行環境](/General/issues_and_resolutions/#flatpak-apps-have-no-hardware-acceleration-on-nvidia)已更新。"
+
+### Bazzite會支持更老的Nvidia顯示卡嗎？
+
+目前，由於Nvidia沒有提供相關的驅動程式，所以Bazzite無法支持Kepler架構或以前的顯卡（大部分GTX700系列或更老的顯卡）。
+
+-   理論上，你可以安裝無`-nvidia`後綴的映像，並使用開源逆向工程搓出來的`nouveau`驅動程式，但由於開源組件無法與閉源的GSP顯卡韌體交通，顯卡將會卡死在最低運行頻率，而性能亦將大幅下降。
+-   在使用官方Bazzite映像時，你不能更改或安裝舊版Nvidia驅動程式。
+-   若然你需要在你的舊Nvidia顯卡上運行Linux，那你可能要安裝另一些Linux發行版。至少在Fedora及其衍生發行版中，這些顯卡已經被Nvidia踢進了棺材。
+
+!!! 額外資訊
+
+    Nvidia從495版開始才初步支持Wayland協定，而最後一個支持Kepler或以前顯卡的驅動程式版本為470。Bazzite不支持運行X11。若你急切需要在Kepler或以前的顯卡上運行遊戲，那你可以嘗試Linux Mint、Debian等仍在使用X11／Xorg的發行版。
+
+### 我剛換了顯卡，我需要做甚麼？
+
+正如上文所提，絕大部分硬件驅動程式都匯集於上游Linux內核中。這代表在更換顯卡或其他硬件後，你**不需要**做任何更新或對系統作任何改動。當然，若你更換了Nvidia顯卡的話，你就需要先[切換更新頻道](../Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/brh.md)，以獲取內置Nvidia驅動程式的映像。
+
+## 當我手動更新時，出現了此錯誤：`error: System transaction in progress`
+
+![](/../img/system-transaction-in-progress.png)
+
+這是因為在[Bazzite桌面版](#1)中，自動更新預設為開啟。因此，你可以無視這個錯誤。
+
+## 在遊玩Windows遊戲時，其提示我的驅動程式為舊版，我該做甚麼？
+
+![](/../img/gpu_driver_warning.png)
+Windows遊戲無法正確偵察Linux驅動程式版本。
+
+-   這是因為Linux與Windows上的版本號並不相同，一些遊戲有的時候會出現此彈窗提示。 
+-   **你可以安全地無視這個錯誤。**
+-   詳情請參考[我需要額外安裝AMD/Intel的顯卡驅動程式嗎](#amdintel)
+
+## Bazzite是否支持兼容性支持模塊(CSM)或主引導記錄(MBR)？
+
+Bazzite不支持兼容性支持模塊(CSM)或主引導記錄(MBR)。Bazzite安裝引導程式會提示你如何停用兼容性支持模塊(CSM)：![CSM](../img/csm.webp)
+
+## 我可以在Bazzite上使用插幀技術，如AFMF、FSR幀生成嗎？
+
+**可以**，但運行的遊戲必須支持FSR3.1或以上版本的超採樣技術。但注意：
+
+-   開源驅動中並沒有類似AFMF的驅動層插幀功能。
+-   有些遊戲模組或[Decky插件](https://github.com/xXJSONDeruloXx/Decky-Framegen)包含類似功能。
+-   若使用`Proton-CachyOS 11.0-20260702`或其衍生版本的遊戲轉譯層，在支持FSR3.1或以上版本的遊戲中，超採樣將自動升級為FSR4.1.1（詳情請參考[Proton-CachyOS的GitHub分頁](https://github.com/CachyOS/proton-cachyos/releases/tag/cachyos-11.0-20260702-slr)）。此外，**Bazzite Portal**亦包含針對於RDNA3架構顯卡的FSR幀生成開關。
+-   若你已購買或擁有[Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/)，你可以在**Bazzite Portal**內安裝Lossless Scaling-Vulkan Layer。
+
+## 我可以安裝GRUB啟動程式(Bootloader)主題嗎
+
+!!! 額外資訊
+
+    Bazzite預設隱藏GRUB，你可以放心食用。
+
+因其帶來的潛在風險（如系統無法啟動），Bazzite不支持安裝GRUB主題。若你在Bazzite上遇上任何問題，請先移除所有GRUB主題。
+
+## 我能更改我的主機名稱（電腦名稱）嗎？
+
+!!! 重要事宜
+
+    由於Distrobox容器相容性問題，主機名稱的長度必須少於20字。
+
+打開系統終端（Terminal），並輸入以下**指令**：
+
+```
+hostnamectl hostname <hostname>
+```
+
+`<hostname>`為你的新主機名稱。
+
+## 我安裝了Windows，然後Bazzite就無法啟動了 { id="windows-bootloader-override" }
+
+這是因為Windows肘擊了Bazzite的GRUB啟動程式。先預備一個Bazzite Live ISO的USB手指，然後啟動至其中，並運行**Bazzite Bootloader Restoration Tool**。
+
+## 我可以在現有的Bazzite系統上切換桌面環境嗎？
+
+<sub> (例：從KDE Plasma切換到GNOME) </sub>
+
+Bazzite**不建議**在現有的系統上切換桌面環境。雖然Bazzite系統映像能在切換更新頻道時完美替換桌面環境系統包的所有系統文件，但各桌面環境的用戶層配置文件不一，在切換時**極易引發衝突**。你可以嘗試設置兩個系統用戶，或使用[Mending Wall](https://flathub.org/en/apps/org.indii.mendingwall)工具，但Bazzite**不建議**或支持這樣做。
+
+最安全，也是Bazzite建議切換桌面環境的**唯一辦法**，是備份你的個人資料，然後重新安裝Bazzite。
+
+## 我可以安裝_這個_桌面環境或_那個_窗口管理器(Window Manager)嗎？
+
+你可以基於Bazzite自定義一個系統映像檔安裝你心儀的桌面環境或窗口管理器，詳情請參考[創建自定義系統映像檔](/Advanced/creating_custom_image.md)。
+
+## `:0` 和 `:1` 在GRUB啟動程式裏是甚麼意思？
+
+GRUB預設在系統錯誤時顯示，在不必要時隱藏。這些數字指的是映像檔版本索引：
+
+-   `:0` = 預設啟動映像／最新更新映像
+-   `:1` = 上一映像檔／後備映像
+
+你亦可以鎖定映像檔版本，使其不會被自動移除。若然你鎖定了一些映像檔版本，它們便會以`:2`、`:3`等的形式出現。
+
+## 為甚麼要叫巴茲特！！！
+
+[Fedora原子化發行版](https://fedoraproject.org/atomic-desktops/)原本基於[礦物](https://fedoraproject.org/kinoite/)來命名。巴茲特（Bazzite，環矽酸鈹鈧，Be3Sc2Si6O18）是一種輕、硬、且為[藍色](https://universal-blue.org/)的礦物。
+
+## 我想要一個類似Bazzite，但不以遊戲為本的系統
+
+Universal Blue提供兩個類似Bazzite，但不以遊戲為本的姊妹作業系統。你仍然可以在這些系統上運行遊戲，但她們不包含Bazzite的預安裝軟件和遊戲專用優化。這三個項目皆同源且共享開發成果：
+
+-   [**Aurora「曙光」**](https://getaurora.dev/) 使用 **KDE Plasma** 桌面環境
+-   [**Bluefin「藍鰭」**](https://projectbluefin.io/) 使用 **GNOME** 桌面環境
+
+## 還有更多的問題？
+
+!!! 溫馨提示
+
+    記得使用右上角／上方的搜尋功能！
+
+Bazzite 強烈建議將問題提交至Bazzite項目GitHub上的[Issue tracker](https://github.com/ublue-os/bazzite/issues)。當然，請記得Bazzite的開發者們也是人類，不是神仙，有一些東西不是説能改就能改的。<small>(_不點名批評某綠色顯卡公司的Linux驅動程式_)</small>

--- a/src/General/FAQ.zh_HK.md
+++ b/src/General/FAQ.zh_HK.md
@@ -1,5 +1,5 @@
 ---
-title: Frequently Asked Questions
+title: 常見問題
 ---
 
 # 常見問題 (FAQ)

--- a/src/General/community-links.zh_HK.md
+++ b/src/General/community-links.zh_HK.md
@@ -1,0 +1,70 @@
+---
+title: Community Resources
+---
+
+# 社區資源
+
+!!! note
+
+    這裏包含一些有用的非官方文檔。
+
+!!! warning
+
+    這些文檔及資源或未更新，閱讀時還請注意。**若資訊有衝突，請以Bazzite 指南(英文)及Bazzite的維護團隊之資訊為準**。
+
+## 硬件
+
+- [**Framework Linux Guides**](https://knowledgebase.frame.work/categories/linux-S1IUEcFbkx)
+- [**Framework Laptop Guides**](https://guides.frame.work/)
+- [**Lenovo Legion Go Tips and Tricks**](https://github.com/aarron-lee/legion-go-tricks)
+- [**How to Update the BIOS on the Lenovo Legion Go from Bazzite (No Windows Required) [*Potential Risk of Bricking Handheld*]**](https://universal-blue.discourse.group/t/how-to-update-the-bios-on-the-lenovo-legion-go-from-bazzite-no-windows-required/3064)
+- [**GPD Win Tips and Tricks**](https://github.com/aarron-lee/gpd-win-tricks)
+- [**Minisforum V3 Tips and Tricks**](https://github.com/aarron-lee/awesome-minisforum-v3)
+- [**HUION H1060P Drawing Tablet Workaround <small>(Also works for other non-Wacom tablets that have issues with OpenTabletDriver)</small>**](https://www.answeroverflow.com/m/1275988149402861709)
+- [**Beelink GTR6 Compatibility List**](https://docs.google.com/spreadsheets/d/1stEL43uuNny6HV4HhV347T0iEprstmahngEJEOqz_b4/)
+- [**Wake on Lan Via Ethernet Tutorial**](https://universal-blue.discourse.group/t/is-wake-on-lan-supported/1165/6)
+- [**USB Wakeup on Bazzite**](https://arnaught.neocities.org/blog/2024/12/28/bazzite-usb-wakeup)
+
+## 運行軟件及遊戲須知
+
+- [**OLD Bazzite Portal Application List**](https://universal-blue.discourse.group/t/old-bazzite-portal-flatpak-list-restored-as-a-forum-post/5440)
+- [**Microsoft's Tutorial on Xbox Cloud Streaming for Game Pass Ultimate (and Fortnite)**](https://support.microsoft.com/en-us/topic/xbox-cloud-gaming-in-microsoft-edge-with-steam-deck-43dd011b-0ce8-4810-8302-965be6d53296)
+- [**Browser Games Using Web Apps**](https://universal-blue.discourse.group/t/how-to-run-old-browser-games-with-web-apps/486)
+- [**StreamingServiceLauncher**](https://github.com/aarron-lee/StreamingServiceLauncher)
+- [**Crunchyroll for Linux**](https://github.com/aarron-lee/crunchyroll-linux)
+- [**Running Valve's Hammer Level Editor Software for Map Making in the Source 1 Engine**](https://andrealmeid.com/post/2020-05-28-csgo-hammer-linux/)
+- [**boxkit: Template to build your own OCI Distrobox container**](https://github.com/ublue-os/boxkit)
+- [**bazzite-arch: Gaming packages inside of a Distrobox container**](https://github.com/ublue-os/bazzite-arch)
+- [**davincibox: Container for DaVinci Resolve installation and runtime dependencies**](https://github.com/zelikos/davincibox)
+- [**DAWbox: An Ubuntu based OCI ready for music production, powered by Distrobox**](https://github.com/Messaiga/DAWbox)
+- [**ZeroTier Setup**](/General/zerotier.md)
+- [**Installing Arctis Manager**](/Advanced/arctis-manager.md)
+
+## 容器為本／原子化更新有關的資源
+
+- [**List of Bootable Container Images**](https://workshop.blue-build.org/images)
+- [**Bootcrew**](https://github.com/bootcrew)
+- [**secureblue**](https://secureblue.dev/)
+- [**Blue95**](https://github.com/winblues/blue95)
+- [**Wayblue**](https://github.com/wayblueorg/wayblue)
+- [**Pocketblue**](https://pocketblue.github.io/)
+- [**HeliumOS**](https://www.heliumos.org/)
+- [**List of Community Created Custom Images**](https://universal-blue.discourse.group/t/list-of-community-created-custom-images/340)
+- [**Installing Universal Blue's Base Images**](https://universal-blue.discourse.group/t/how-to-install-universal-blues-base-images/868)
+- [**Self-Hosting Images**](https://github.com/ublue-os/forge)
+- [**BlueBuild Project**](https://blue-build.org/)
+
+## 參考資料及文檔
+
+- [**Fedora Kinoite Documentation**](https://docs.fedoraproject.org/en-US/fedora-kinoite/)
+- [**Fedora Silverblue Documentation**](https://docs.fedoraproject.org/en-US/fedora-silverblue/)
+- [**Aurora Documentation**](https://docs.getaurora.dev/)
+- [**Bluefin Documentation**](https://docs.projectbluefin.io/)
+- [**Bazzite Newsletter Archive**](https://universal-blue.discourse.group/t/bazzite-newsletters/2252)
+- [**DeepWiki**](https://deepwiki.com/ublue-os/bazzite)
+
+<hr>
+
+## 合作與貢獻
+
+幫助我們更新Bazzite 指南，加入更多有用的資訊！

--- a/src/General/community-links.zh_HK.md
+++ b/src/General/community-links.zh_HK.md
@@ -1,5 +1,5 @@
 ---
-title: Community Resources
+title: 社區資源
 ---
 
 # 社區資源

--- a/src/General/index.zh_HK.md
+++ b/src/General/index.zh_HK.md
@@ -1,0 +1,19 @@
+---
+title: General Guides
+---
+
+# 常見教程
+
+- [**常見問題**](/General/FAQ.md)
+- [**Dictionary & Terminology**](/General/terms.md)
+- [**Comparison of Bazzite and Fedora Atomic Desktop**](/General/Fedora_Atomic_Comparison.md)
+- [**SteamOS Comparison**](/General/SteamOS_Comparison.md)
+- [**桌面環境設置**](/General/Desktop_Environment_Tweaks.md)
+- [**VPN Setup**](/General/VPN.md)
+- [**Issues & Resolution**](/General/issues_and_resolutions.md)
+- [**Reporting Bugs**](/General/reporting_bugs.md)
+- [**Community Resources**](/General/community-links.md)
+- [**Security Policy**](https://github.com/ublue-os/bazzite/blob/main/SECURITY.md)
+- [**License**](https://github.com/ublue-os/bazzite/blob/main/LICENSE)
+- [**Press Kit**](https://github.com/ublue-os/bazzite/tree/main/press_kit)
+- [**Uninstalling Bazzite**](/General/uninstalling-bazzite.md)

--- a/src/General/index.zh_HK.md
+++ b/src/General/index.zh_HK.md
@@ -1,5 +1,5 @@
 ---
-title: General Guides
+title: 常見教程
 ---
 
 # 常見教程

--- a/src/donations.md
+++ b/src/donations.md
@@ -78,7 +78,7 @@ Enjoy using Bazzite and want to help sustain its development? Consider sponsorin
 {{ contributor("stellaberrant", "stellaberrant", "Translations and bug fixes") }}
 {{ contributor("wolfyreload", "wolfyreload", "Visual Guides on YouTube, QA Testing") }}
 {{ contributor("Dylan Taylor", "dylanmtaylor", "Image and CI/CD work, new release enablement, and testing", "https://github.com/sponsors/dylanmtaylor") }}
-{{ contributor("Alex Shek", "ykshek", "Advanced features like custom resolution support") }}
+{{ contributor("Alex Shek", "ykshek", "Bazzite Portal, UX enhancements, advanced features & translations") }}
 {{ contributor("Crono", "EPOCHvoyager", "Significant testing", "https://github.com/sponsors/EPOCHvoyager") }}
 
 </div>

--- a/src/index.zh_HK.md
+++ b/src/index.zh_HK.md
@@ -1,0 +1,112 @@
+---
+title: Home
+hide:
+  - navigation
+---
+
+# Bazzite，啟動！
+
+<div class="grid cards _bz" markdown>
+
+- [:material-harddisk: **安裝Bazzite**](General/Installation_Guide/index.md){ style="font-size: 1.1rem" }
+
+  Bazzite可以運行於絕大部分x86-64架構的桌機和筆記本之上。此外，Bazzite亦有針對於特定設備的支持，例如 [Framework](https://frame.work/). <br>
+
+  Bazzite亦支持以控制器為主要交互方式的系統和設備，如家庭劇院（HTPC）以及各式各樣的掌機：
+  
+  - [華碩ROG Ally系列][ally]
+  - [聯想Legion Go系列][legion_go]
+  - [GPD掌機][gpd]
+  - [OneXPlayer掌機][onex]
+  - [Ayn掌機][ayn]
+  - [Ayaneo掌機][ayaneo]
+  - [Steam Deck][deck]
+  - [其他x86-64架構的掌機][otherhand]
+
+- [:material-controller: **遊玩及安裝遊戲**][gaming]{ style="font-size: 1.1rem" }
+
+  :fontawesome-brands-steam: [Steam](https://store.steampowered.com) 和 [Lutris](Gaming/Game_Launchers.md#non-steam-games) 都已經預先安裝於Bazzite系統之中，為你打造一個裝完即玩嘅體驗！<sup>1</sup>
+
+  此外，Bazzite亦兼容其他遊戲啟動器：
+
+  - [Heroic Games Launcher](https://heroicgameslauncher.com/)為你提供無縫遊玩Epic遊戲的體驗
+  - 可於內設應用程式商店安裝的遊戲啟動器，例如[osu!](https://flathub.org/zh-Hant/apps/sh.ppy.osu)和[Minecraft](https://flathub.org/zh-Hant/apps/org.prismlauncher.PrismLauncher)
+  - ...以及[其他遊戲！](https://flathub.org/zh-Hant/apps/category/game/1)
+
+  <small>\*<sup>1</sup> 大多數電腦游戲都可以透過Wine/Proton運行於Linux之上，詳情請參考 [**ProtonDB**](https://protondb.com)、[**Are We Anti-Cheat Yet?**](https://areweanticheatyet.com)和[**Can We Tux?**](https://tux.red/)</small>
+
+- [:material-download-circle: **安裝軟件**][installing_software]{ style="font-size: 1.1rem" }
+
+  <small>註：由上之下的次序代表各種安裝途徑的推介先序</small>
+
+  1. [Bazzite Portal][bazzite_portal]使用Bazzite獨家的安裝方式
+     {style="list-style-type: decimal;"}
+  2. [Bazaar 應用程式商店 (Flatpak)][flatpak]包含大部份應用程式
+     {style="list-style-type: decimal;"}
+  3. [Homebrew][homebrew]包含各種指令行軟件及工具
+     {style="list-style-type: decimal;"}
+  4. [Distrobox容器][containers]提供各大Linux發行版的安裝包管理器(如`apt`、`dnf`、`pacman`等等)，通常用於開發工具和網頁寄存（Web Hosting）
+     {style="list-style-type: decimal;"}
+  5. [Appimage][appimage]作為「綠色軟體」的載體
+     {style="list-style-type: decimal;"}
+
+  此外，你亦可使用Bazzite系統內建的[`rpm-ostree`疊加套件到系統樹上][rpm-ostree]，但如非必要，我們並[不推介使用這個方法][rpm-ostree_caveats]。
+
+- [:fontawesome-solid-circle-arrow-down: **系統更新與回溯**][updateindex]{ style="font-size: 1.1rem" }
+
+  Bazzite使用Fedora原子化更新系統，每次更新皆為啟動一個完整的唯讀系統映像檔。若更新後，你的系統出現異常，你可以回溯至90日內任意一個系統映像檔，而你的個人檔案皆不會受影響。
+
+  - [更新指南][updates]
+  - [系統回溯][rollbacks]
+  - [切換更新頻道][rebasing]
+  - [Bazzite更新助手(`bazzite-rollback-helper`)][rollback-helper]
+
+- [:fontawesome-brands-android: **Android應用程式**][waydroid]{ style="font-size: 1.1rem" }
+
+  你可以在[Waydroid](https://waydro.id/)內運行Android的應用程式!
+
+  - 運行由辦公軟件和手機遊戲之間的任意應用程式
+  - 支持於大部分應用程式上的自動ARM架構轉譯
+  - 在毋須擔憂DRM限制的情況下使用各種串流軟件
+  - 透過[Google Play Store](https://play.google.com/store/games)和[F-Droid](https://f-droid.org/)安裝軟件
+
+- [:fontawesome-solid-handshake: **合作與貢獻**][contrib]{ style="font-size: 1.1rem" }
+
+  Bazzite從上游[Universal Blue](https://universal-blue.org/)帶來的一大特點是其開源貢獻的簡易性
+
+  - 新系統壞了？你可以在[這裡提交Bug報告](General/reporting_bugs.md)
+  - 在[自定義映像][customimage]裏測試你的修改
+  - 幫助我們更新**Bazzite 指南**和[加入翻譯文檔](https://github.com/KyleGospo/docs.bazzite.gg/blob/main/README.md#translate-documentation)！
+
+</div>
+
+[deck]:  Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.md
+[ally]: Handheld_and_HTPC_edition/Handheld_Wiki/ASUS_ROG_Ally.md
+[legion_go]: Handheld_and_HTPC_edition/Handheld_Wiki/Lenovo_Legion_Go.md
+[ayn]: Handheld_and_HTPC_edition/Handheld_Wiki/Ayn_Handhelds.md
+[onex]: Handheld_and_HTPC_edition/Handheld_Wiki/OneXPlayer_Handhelds.md
+[gpd]: Handheld_and_HTPC_edition/Handheld_Wiki/GPD_Handhelds.md
+[ayaneo]: Handheld_and_HTPC_edition/Handheld_Wiki/Ayaneo_Handhelds.md
+[run_win_game]: Installing_and_Managing_Software/index.md#how-do-i-run-windows-applications
+[enable_proton]: Gaming/Game_Launchers.md#enabling-proton-for-all-steam-games
+[flatpak]: Installing_and_Managing_Software/Flatpak.md
+[bazzite_portal]: Installing_and_Managing_Software/Bazzite_Portal.md
+[rpm-ostree]: Installing_and_Managing_Software/rpm-ostree.md
+[distrobox]: Installing_and_Managing_Software/Distrobox.md
+[installing_software]: Installing_and_Managing_Software/index.md
+[contrib]: https://universal-blue.org/contributing.html
+[homebrew]: Installing_and_Managing_Software/Homebrew.md
+[rpm-ostree_caveats]: Installing_and_Managing_Software/rpm-ostree.md#major-caveats-using-rpm-ostree
+[steam_game_mode]: Handheld_and_HTPC_edition/Steam_Gaming_Mode.md#what-is-steam-gaming-mode
+[appimage]: Installing_and_Managing_Software/AppImage.md
+[updateindex]: Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/index.md/
+[updates]: Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/updating_guide.md/
+[rollbacks]: Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rolling_back_system_updates.md/
+[rebasing]: Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide.md/
+[rollback-helper]: Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/bazzite_rollback_helper.md/
+[waydroid]: Installing_and_Managing_Software/Waydroid_Setup_Guide.md
+[gaming]: Gaming/index.md
+[quadlet]: Installing_and_Managing_Software/Quadlet.md
+[otherhand]: Handheld_and_HTPC_edition/Handheld_Wiki/Other_Handhelds.md
+[customimage]: Advanced/creating_custom_image.md
+[containers]: Installing_and_Managing_Software/Containers.md

--- a/src/index.zh_HK.md
+++ b/src/index.zh_HK.md
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: 首頁
 hide:
   - navigation
 ---


### PR DESCRIPTION
This currently includes:
Index(Homepage)
General Index
General/Community-links
General/Desktop-Environment-Tweaks
General/FAQ

I also added [**Can We Tux?**](https://tux.red/) in the Chinese Index(Homepage), which is a Chinese(Simplified) site about the state of commonly used software in China on Linux. Not sure if this is allowed or not.

There is also additional cleanups in General/FAQ for en docs.

Additionally, I updated my contribution description.

P.S. Also, for some reason, mkdocs can't seem to handle zh_Hant(Chinese (Traditional)/中文（繁體）), so I used zh_HK(Chinese (Hong Kong)/中文（香港）) instead.