### PR TITLE
Fix wording in README for YAML metadata section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You will need other tools as well, like:
 
 You can add more explicit page titles (used by the browser tab names) by using YAML metadata.
 
-Adding this at the start of the markdown file would change the tab name to "Hello world":
+Adding this at the start of the markdown file will change the tab name to "Hello world":
 
 ```yaml
 ---


### PR DESCRIPTION
(### 2. ) will instead of would, right before the "hello world" part.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
