### PR TITLE
Add note about Waydroid compatibility with Nvidia hardware

### DIFF
--- a/src/Installing_and_Managing_Software/Waydroid_Setup_Guide.md
+++ b/src/Installing_and_Managing_Software/Waydroid_Setup_Guide.md
@@ -11,6 +11,7 @@ title: Waydroid Setup Guide
 !!! attention
 
     Waydroid does **not** work on Nvidia hardware.
+    
 
 ![Waydroid](../img/Waydroid.jpeg)
 


### PR DESCRIPTION
Trying to add more separation between: "Attention

Waydroid does not work on Nvidia hardware." and the image that comes after.

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
