### PR TITLE
fix(deps): Various bootstrap script changes for non-atomic (?) build environments

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -35,8 +35,3 @@ _fmt-headers:
     rg '^#\s' src/ --json \
     | jq -rs '.[] | select(.type=="end") | {file: .data.path.text, number: .data.stats.matches} | select(.number > 1) | .file' \
     | xargs -I{} sed -i -E 's/(^#+) /\1# /' {}
-
-[env("FOO", "bar")]
-uv_test +ARGS="":
-    /usr/bin/true
-    echo $FOO

--- a/Justfile
+++ b/Justfile
@@ -10,14 +10,15 @@ _default:
 install_dependencies:
     bash ./utils/install-deps.sh
 
+# Workaround for the cairo libs missing error in macOS when only a Homebrew installed cairo is available.
+# Should no-op for non-macOS environments, and shouldn't hurt if cairo is available otherwise.
+# Both Intel and Apple Silicon default paths for Homebrew are covered.
+# Source: https://t.ly/MfX6u (modified to add Intel search path)
+# TODO: Make this platform-specific, or run proper detection beforehand.
+[env("DYLD_FALLBACK_LIBRARY_PATH", "/opt/homebrew/lib:/usr/local/homebrew/lib")]
 mkdocs +ARGS="":
     rm -rf {{ MKDOCS_DIR }}/.cache/cmdrun
-    # Workaround for the cairo libs missing error in macOS when only a Homebrew installed cairo is available.
-    # Should no-op for non-macOS environments, and shouldn't hurt if cairo is available otherwise.
-    # Both Intel and Apple Silicon default paths for Homebrew are covered.
-    # Source: https://t.ly/MfX6u (modified to add another search path)
-    # TODO: Make this platform-specific, or run proper detection beforehand.
-    DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:/usr/local/homebrew/lib uv run mkdocs {{ ARGS }}
+    uv run mkdocs {{ ARGS }}
 
 mkdocs_clean:
     rm -rf {{ MKDOCS_DIR }}/.cache

--- a/Justfile
+++ b/Justfile
@@ -12,7 +12,11 @@ install_dependencies:
 
 mkdocs +ARGS="":
     rm -rf {{ MKDOCS_DIR }}/.cache/cmdrun
-    uv run mkdocs {{ ARGS }}
+    # Workaround for the cairo libs missing error in macOS when only a Homebrew installed cairo is available.
+    # Should no-op for non-macOS environments, and shouldn't hurt if cairo is available otherwise.
+    # Both Intel and Apple Silicon default paths for Homebrew are covered.
+    # Source: https://t.ly/MfX6u (modified to add another search path)
+    DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:/usr/local/homebrew/lib uv run mkdocs {{ ARGS }}
 
 mkdocs_clean:
     rm -rf {{ MKDOCS_DIR }}/.cache

--- a/Justfile
+++ b/Justfile
@@ -10,15 +10,18 @@ _default:
 install_dependencies:
     bash ./utils/install-deps.sh
 
-# Workaround for the cairo libs missing error in macOS when only a Homebrew installed cairo is available.
+# Workaround for the cairo error in macOS when only a Homebrew installed cairo is available.
 # Should no-op for non-macOS environments, and shouldn't hurt if cairo is available otherwise.
 # Both Intel and Apple Silicon default paths for Homebrew are covered.
-# Source: https://t.ly/MfX6u (modified to add Intel search path)
-# TODO: Make this platform-specific, or run proper detection beforehand.
-[env("DYLD_FALLBACK_LIBRARY_PATH", "/opt/homebrew/lib:/usr/local/homebrew/lib")]
+# Due to macOS limitations, this variable MUST be explicitly passed to the direct invocation,
+# thus rendering the env approach impossible.
+# Sources:
+# - https://t.ly/MfX6u (modified to add Intel search path)
+# - https://apple.stackexchange.com/questions/212945/unable-to-set-dyld-fallback-library-path-in-shell-on-osx-10-11-1
+# [env("DYLD_FALLBACK_LIBRARY_PATH", "/opt/homebrew/lib:/usr/local/homebrew/lib")]
 mkdocs +ARGS="":
     rm -rf {{ MKDOCS_DIR }}/.cache/cmdrun
-    uv run mkdocs {{ ARGS }}
+    DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:/usr/local/homebrew/lib uv run mkdocs {{ ARGS }}
 
 mkdocs_clean:
     rm -rf {{ MKDOCS_DIR }}/.cache
@@ -32,3 +35,8 @@ _fmt-headers:
     rg '^#\s' src/ --json \
     | jq -rs '.[] | select(.type=="end") | {file: .data.path.text, number: .data.stats.matches} | select(.number > 1) | .file' \
     | xargs -I{} sed -i -E 's/(^#+) /\1# /' {}
+
+[env("FOO", "bar")]
+uv_test +ARGS="":
+    /usr/bin/true
+    echo $FOO

--- a/Justfile
+++ b/Justfile
@@ -16,6 +16,7 @@ mkdocs +ARGS="":
     # Should no-op for non-macOS environments, and shouldn't hurt if cairo is available otherwise.
     # Both Intel and Apple Silicon default paths for Homebrew are covered.
     # Source: https://t.ly/MfX6u (modified to add another search path)
+    # TODO: Make this platform-specific, or run proper detection beforehand.
     DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib:/usr/local/homebrew/lib uv run mkdocs {{ ARGS }}
 
 mkdocs_clean:

--- a/utils/install-deps.sh
+++ b/utils/install-deps.sh
@@ -18,7 +18,7 @@ for pkg in $brew_installs ; do
     fi
 done
 
-if [[ -n "$needs_brew" ]]; then
+if [[ $needs_brew -eq 1 ]]; then
     if ! command -v brew >/dev/null; then
         echod "Some required packages are missing, and brew is not available for a userspace-only installation."
         echod "If you are on a non-atomic system, installing them via your system package manager works as well."

--- a/utils/install-deps.sh
+++ b/utils/install-deps.sh
@@ -11,7 +11,7 @@ brew_installs=(
 )
 
 # Skip brew requirement when all the required programs are available otherwise.
-for pkg in $brew_installs ; do
+for pkg in "${brew_installs[@]}" ; do
     if ! command -v $pkg >/dev/null; then
         echod "Missing package: $pkg"
         needs_brew=1

--- a/utils/install-deps.sh
+++ b/utils/install-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 REPO_DIR="$(git rev-parse --show-toplevel)"
 

--- a/utils/install-deps.sh
+++ b/utils/install-deps.sh
@@ -10,12 +10,21 @@ brew_installs=(
     rg
 )
 
-if ! command -v brew >/dev/null; then
-    echod "This script needs 'brew' to run"
-    exit 1
-fi
+# Skip brew requirement when all the required programs are available otherwise.
+for i in $brew_installs ; do
+    if ! command -v $i >/dev/null; then
+        needs_brew=1
+    fi
+done
 
-brew install "${brew_installs[@]}"
+if [[ -n "$needs_brew" ]]; then
+    if ! command -v brew >/dev/null; then
+        echod "This script needs 'brew' to run"
+        exit 1
+    else
+        brew install "${brew_installs[@]}"
+    fi
+fi
 
 # Install project
 echod "Setting up python project"

--- a/utils/install-deps.sh
+++ b/utils/install-deps.sh
@@ -11,15 +11,17 @@ brew_installs=(
 )
 
 # Skip brew requirement when all the required programs are available otherwise.
-for i in $brew_installs ; do
-    if ! command -v $i >/dev/null; then
+for pkg in $brew_installs ; do
+    if ! command -v $pkg >/dev/null; then
+        echod "Missing package: $pkg"
         needs_brew=1
     fi
 done
 
 if [[ -n "$needs_brew" ]]; then
     if ! command -v brew >/dev/null; then
-        echod "This script needs 'brew' to run"
+        echod "Some required packages are missing, and brew is not available for a userspace-only installation."
+        echod "If you are on a non-atomic system, installing them via your system package manager works as well."
         exit 1
     else
         brew install "${brew_installs[@]}"


### PR DESCRIPTION
This changes some steps and configurations in the Justfile and the dependency installation scripts to better fit build environments that are not subject to some specific restrictions from Bazzite or other atomic systems.

- Makes `brew` an optional dependency, skipping it if `uv`, `just`, and `rg` are already available otherwise. This helps with conventional Linux distro environments where the user can just use the package manager, or can provide the required packages in some other way.
- Adds a `DYLD_LIBRARY_FALLBACK_PATH` to the mkdocs invocation per [mkdocs-material's official documentation](https://t.ly/MfX6u). This helps when building on macOS with cairo installed via Homebrew. Ideally it should be a env in the Justfile definition, but is not possible due to [macOS security restrictions](https://apple.stackexchange.com/questions/212945/unable-to-set-dyld-fallback-library-path-in-shell-on-osx-10-11-1).

Tested on stock Fedora and Apple Silicon macOS.