### PR TITLE
docs(homebrew): add fonts section

### DIFF
--- a/src/Installing_and_Managing_Software/Homebrew.md
+++ b/src/Installing_and_Managing_Software/Homebrew.md
@@ -30,6 +30,27 @@ brew install <package>
 
 The [Bold Brew application](https://bold-brew.com/) offers a terminal user interface (TUI) for installing common Homebrew packages.
 
+## Fonts
+
+Homebrew is also used for installing fonts, browse [this page](https://formulae.brew.sh/cask-font/) and install your favorite fonts. They will be copied into `~/.local/share/fonts`
+
+- Microsoft Fonts:
+
+If you need to install Microsoft fonts in order to ensure compatibility with some documents, most of them are in Homebrew.
+
+Be aware that some of these fonts are copyrighted by Microsoft.
+Microsoft UK confirmed you are allowed to have them, provided that you own a copy of either:
+
+- Microsoft PowerPoint Viewer (free, retired)
+- May include PowerPoint Mobile (free)
+- Microsoft Office (Any version, Windows or Mac)
+
+Calibri, Cambria, Candara, Consolas, Constantia and Corbel are included in font-microsoft-office, the others must be installed individually. You can install all of them at once by running the following command in a terminal:
+
+```
+brew tap colindean/fonts-nonfree && brew install --cask font-microsoft-office font-microsoft-aptos font-arial font-arial-black font-courier-new font-times-new-roman font-georgia
+```
+
 ## Project Website
 
 https://brew.sh/


### PR DESCRIPTION
Added a section describing font installation through homebrew, copied from https://docs.projectbluefin.io/command-line/#fonts

Not sure if this is the right section for this addition, sorry if it isn't!

<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->
